### PR TITLE
ユーザログイン、新規登録ページのUIを実装

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,7 +3,7 @@
     <Header></Header>
     <!-- ルートコンポーネントでページのメイン部分の表示 -->
     <v-container class="my-16">
-        <router-view></router-view>
+      <router-view class="mx-lg-16 my-lg-8"></router-view>
     </v-container>
   </v-app>
 </template>

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -8,9 +8,12 @@
       fixed
       temporary
     >
+      <!-- 線 -->
+      <v-divider></v-divider>
+
       <!-- メニュー表のリスト -->
       <v-list>
-        <!-- <template v-if="!authUser">
+        <template v-if="!authUser">
           <v-list-item
             v-for="item in items"
             :key="item.title"
@@ -26,10 +29,9 @@
               <v-list-item-title>{{ item.title }}</v-list-item-title>
             </v-list-item-content>
           </v-list-item>
-        </template> -->
+        </template>
 
-        <!-- <template v-else> -->
-        <template>
+        <template v-else>
           <!-- リストを繰り返し処理で全て表示 -->
           <v-list-item
             v-for="item in itemsLogin"
@@ -55,7 +57,7 @@
 </template>
 
 <script>
-// import { mapGetters, mapActions } from "vuex"
+import { mapGetters, mapActions } from "vuex"
 
 export default {
   // 親のHeader.vueから引き継ぎ
@@ -70,18 +72,43 @@ export default {
       // 未ログインのメニューリスト
       items: [
         { title: 'トップページ', icon: 'mdi-home-outline', url: '/' },
-        // { title: 'ログイン', icon: 'mdi-login', url: '/login' },
-        // { title: '新規登録', icon: 'mdi-account-plus', url: '/register' },
+        { title: 'ログイン', icon: 'mdi-login', url: '/login' },
+        { title: '新規登録', icon: 'mdi-account-plus', url: '/register' },
       ],
       // ログイン中のメニューリスト
       itemsLogin: [
         { title: 'トップページ', icon: 'mdi-home-outline', url: '/' },
-        { title: 'お気に入り地点', icon: 'mdi-heart-outline', url: '' },
-        { title: '地点リクエスト', icon: 'mdi-send-outline', url: '' },
-        // { title: 'ログアウト', icon: 'mdi-logout', action: "logout" },
+        // { title: 'お気に入り地点', icon: 'mdi-heart-outline', url: '' },
+        // { title: '地点リクエスト', icon: 'mdi-send-outline', url: '' },
+        { title: 'ログアウト', icon: 'mdi-logout', action: "logout" },
       ],
       right: null,
     }
   },
+  computed: {
+    // mapGettersでログイン中のユーザを取得
+    ...mapGetters("users", ["authUser"])
+  },
+  methods: {
+    // mapActionでログアウト処理を呼び出し
+    ...mapActions("users", ["logoutUser"]),
+    // メニューの中でログアウトメニューをクリックした時のみ発火
+    triggerClick(action) {
+      if (action === 'logout') {
+        this.logout()
+      }
+    },
+    // ログアウトを実行するメソッド
+    async logout() {
+      try {
+        // ログアウト処理
+        await this.logoutUser()
+        // // ログアウト後、ログインページに遷移させる
+        this.$router.push({name: 'Login'})
+      } catch (error) {
+        console.log(error)
+      }
+    },
+  }
 }
 </script>

--- a/src/pages/SpotResult.vue
+++ b/src/pages/SpotResult.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="mx-lg-16 mt-lg-10" style="color: #455A64;">
+  <div style="color: #455A64;">
     <h2>{{ area.name }}</h2>
     <v-divider class="mb-2"></v-divider>
     <v-row no-gutters class="my-5">

--- a/src/pages/auth/Login.vue
+++ b/src/pages/auth/Login.vue
@@ -1,0 +1,100 @@
+<template>
+  <div>
+    <v-row justify="center">
+      <v-col cols="11" sm="10" md="8" lg="6">
+        <v-card>
+          <v-form v-model="valid">
+            <v-card-text>
+              <v-text-field
+                v-model="user.email"
+                :rules="emailRules"
+                prepend-icon="mdi-email"
+                label="メールアドレス"
+                validate-on-blur
+                required
+              ></v-text-field>
+
+              <v-text-field
+                v-model="user.password"
+                :rules="passwordRules"
+                prepend-icon="mdi-lock"
+                :append-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
+                :type="showPassword ? 'text' : 'password'"
+                label="パスワード"
+                placeholder="8〜12文字"
+                validate-on-blur
+                required
+                @click:append="showPassword = !showPassword"
+              ></v-text-field>
+            </v-card-text>
+
+            <v-card-actions class="justify-end">
+              <v-btn
+                color="info"
+                outlined
+                class="mr-2"
+                width="100px"
+                type="submit"
+                :disabled="!valid || loading"
+                :loading="loading"
+                @click="login"
+              >
+                ログイン
+              </v-btn>
+            </v-card-actions>
+
+          </v-form>
+
+          <v-divider></v-divider>
+          <v-card-text class="text-center">
+            新規登録は<router-link to="/register">こちら</router-link>
+          </v-card-text>
+
+        </v-card>
+      </v-col>
+    </v-row>
+  </div>
+</template>
+
+<script>
+import { mapActions } from "vuex"
+
+export default {
+  data() {
+    return {
+      // ログインボタンの有効状態を表す(trueで有効)
+      valid: false,
+      loading: false,
+      user: {
+        email: "",
+        password: "",
+      },
+      // メールアドレスのバリデーション
+      emailRules: [
+        v => !!v || 'メールアドレスを入力してください',
+        v => /.+@.+\..+/.test(v) || '無効なメールアドレスです'
+      ],
+      // パスワードのバリデーション
+      passwordRules: [
+        v => !!v || 'パスワードを入力してください',
+        v => v.length <= 12 || '6〜12文字が有効です',
+        v => v.length >= 8 || '8〜12文字が有効です',
+      ],
+      // パスワードの表示状態を表す(trueで表示)
+      showPassword: false,
+    }
+  },
+  methods: {
+    // mapActionでログイン処理を呼び出し
+    ...mapActions("users", ["loginUser"]),
+    login() {
+      try {
+        this.loginUser(this.user);
+        this.$router.push({ name: 'Home' })
+      } catch (error) {
+        console.log(error);
+      }
+    }
+  }
+}
+</script>

--- a/src/pages/auth/Register.vue
+++ b/src/pages/auth/Register.vue
@@ -1,0 +1,128 @@
+<template>
+  <div>
+    <v-row justify="center">
+      <v-col cols="11" sm="10" md="8" lg="6">
+        <v-card>
+          <v-form v-model="valid">
+            <v-card-text>
+              <v-text-field
+                v-model="user.name"
+                :rules="nameRules"
+                prepend-icon="mdi-account-circle"
+                label="お名前"
+                placeholder="2〜10文字"
+                validate-on-blur
+                required
+              ></v-text-field>
+
+              <v-text-field
+                v-model="user.email"
+                :rules="emailRules"
+                prepend-icon="mdi-email"
+                label="メールアドレス"
+                validate-on-blur
+                required
+              ></v-text-field>
+
+              <v-text-field
+                v-model="user.password"
+                :rules="passwordRules"
+                prepend-icon="mdi-lock"
+                :append-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
+                :type="showPassword ? 'text' : 'password'"
+                label="パスワード"
+                placeholder="8〜12文字"
+                validate-on-blur
+                required
+                @click:append="showPassword = !showPassword"
+              ></v-text-field>
+
+              <v-text-field
+                v-model="user.password_confirmation"
+                :rules="passwordRules"
+                prepend-icon="mdi-lock-outline"
+                :append-icon="showPasswordConfirmation ? 'mdi-eye' : 'mdi-eye-off'"
+                :type="showPasswordConfirmation ? 'text' : 'password'"
+                label="パスワー確認"
+                placeholder="8〜12文字"
+                validate-on-blur
+                required
+                @click:append="showPasswordConfirmation = !showPasswordConfirmation"
+              ></v-text-field>
+            </v-card-text>
+
+            <v-card-actions  class="justify-end">
+              <v-btn
+                color="info"
+                outlined
+                class="mr-2"
+                width="100px"
+                type="submit"
+                :disabled="!valid" @click="register"
+              >
+                新規登録
+              </v-btn>
+            </v-card-actions>
+
+          </v-form>
+
+          <v-divider></v-divider>
+          <v-card-text class="text-center">
+            ログインは<router-link to="/login">こちら</router-link>
+          </v-card-text>
+
+        </v-card>
+      </v-col>
+    </v-row>
+  </div>
+</template>
+
+<script>
+import { mapActions } from "vuex"
+
+export default {
+  name: "RegisterIndex",
+  data() {
+    return {
+      valid: false,
+      user: {
+        name: '',
+        email: '',
+        password: '',
+        password_confirmation: '',
+      },
+      nameRules: [
+        v => !!v || 'お名前を入力してください',
+        v => v.length <= 10 || '2〜10文字が有効です',
+        v => v.length >= 2 || '2〜10文字が有効です',
+      ],
+      emailRules: [
+        v => !!v || 'メールアドレスを入力してください',
+        v => /.+@.+\..+/.test(v) || '無効なメールアドレスです'
+      ],
+      passwordRules: [
+        v => !!v || 'パスワードを入力してください',
+        v => v.length <= 12 || '6〜12文字が有効です',
+        v => v.length >= 8 || '8〜12文字が有効です',
+      ],
+      showPassword: false,
+      showPasswordConfirmation: false,
+    }
+  },
+  methods: {
+    ...mapActions("users", [
+      "registerUser"
+    ]),
+    // 新規登録を実行するメソッド
+    register() {
+      try {
+        // 新規登録処理
+        this.registerUser(this.user);
+        this.$router.push({ name: 'Login' })
+      } catch (error) {
+        console.log(error)
+      }
+    }
+  }
+}
+</script>

--- a/src/router.js
+++ b/src/router.js
@@ -1,7 +1,10 @@
 import Vue from "vue";
 import Router from "vue-router";
+import store from "./store"
 import Home from "./pages/Home.vue"
 import SpotResult from "./pages/SpotResult.vue"
+import Login from "./pages/auth/Login.vue"
+import Register from "./pages/auth/Register.vue"
 
 // VueRouterの宣言
 Vue.use(Router)
@@ -12,13 +15,32 @@ const router = new Router({
   mode: "history",
   routes: [
     {
-      path: "/", component: Home, name: "Home",
+      path: "/", component: Home, name: "Home"
     },
     {
-      path: "/countries/:id", component: SpotResult, name: "SpotResult", props: true
+      path: "/countries/:id", component: SpotResult, name: "SpotResult", props: true,
+    },
+    {
+      path: "/login", component: Login, name: "Login"
+    },
+    {
+      path: "/register", component: Register, name: "Register",
     },
   ]
 })
 
+// ページ遷移時に必ず実行される
+router.beforeEach((to, from, next) => {
+  // storeに認証済みのユーザが存在するかを問合せる
+  store.dispatch("users/fetchAuthUser")
+  .then(authUser => {
+    // 認証済みユーザーが存在しないかつ遷移先のページが要ログインのページであればログインページに飛ばすという処理
+    if (to.matched.some(record => record.meta.requiredAuth) && !authUser) {
+      next({ name: "Login" });
+    } else {
+      next();
+    }
+  })
+});
 
 export default router;

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,7 +1,11 @@
 import Vue from "vue"
 import Vuex from "vuex"
+import users from "./modules/users"
 
 Vue.use(Vuex)
 
 export default new Vuex.Store({
+  modules: {
+    users,
+  }
 })

--- a/src/store/modules/users.js
+++ b/src/store/modules/users.js
@@ -1,0 +1,89 @@
+import axios from "../../plugins/axios";
+
+const state = {
+  authUser: null,
+  users: []
+};
+
+const getters = {
+  authUser: (state) => state.authUser,
+  users: state => state.users,
+};
+
+const mutations = {
+  // current_userをstateに保持させる
+  setUser: (state, user) => {
+    state.authUser = user;
+  },
+  // 新規ユーザをUserテーブルに追加
+  addUser: (state, user) => {
+    state.users.push(user)
+  }
+};
+
+const actions = {
+  async loginUser({ commit }, user) {
+    // Rails側にユーザーのログイン情報を送り、返ってきたレスポンスをsessionsResponseという定数に定義している
+    const sessionsResponse = await axios.post("/login", user);
+    if (sessionsResponse.data.token != null) {
+      // レスポンスのtoken部分を抽出し、localStorageのauth_tokenに保持させる
+      localStorage.auth_token = sessionsResponse.data.token;
+      // tokenをBearerヘッダー入れることでapi通信するたびに毎回tokenを設定する必要がなくなるように設定（ステートレス）
+      axios.defaults.headers.common[ "Authorization" ] = `Bearer ${localStorage.auth_token}`;
+      // current_userの取得
+      const userResponse = await axios.get("/users/me");
+      commit("setUser", userResponse.data);
+    } else {
+      alert("メールアドレスとパスワードが違います")
+    }
+  },
+  // ログアウト処理
+  logoutUser({ commit }) {
+    // localStorageからauth_tokenに削除
+    localStorage.removeItem("auth_token");
+    // tokenをBearerヘッダーから消す
+    axios.defaults.headers.common["Authorization"] = "";
+    // current_userをnulにする
+    commit("setUser", null);
+  },
+  // 新規登録メソッド
+  registerUser({ commit }, user) {
+    axios.post("/register", user)
+    .then(res => {
+      commit("addUser", res.data)
+    })
+    .catch(err => {
+      console.log(err)
+    })
+  },
+
+  // current_userが存在するかを確認
+  async fetchAuthUser({ commit, state }) {
+    // localStorageにauth_tokenが無ければログインしていないということでその時点で終了
+    if (!localStorage.auth_token) return null;
+    // stateに認証済みユーザーが入ればそれを返す
+    if (state.authUser) return state.authUser;
+    // ユーザー情報をサーバに問い合わせ、レスポンスをステートに設定し、そのレスポンスを返却する
+    const userResponse = await axios.get("/users/me").catch(err => {
+      console.log(err.response)
+      return null;
+    });
+    if (!userResponse) return null;
+    const authUser = userResponse.data;
+    if (authUser) {
+      commit("setUser", authUser);
+      return authUser;
+    } else {
+      commit("setUser", null);
+      return null;
+    }
+  }
+};
+
+export default {
+  namespaced: true,
+  state,
+  getters,
+  mutations,
+  actions,
+};


### PR DESCRIPTION
## 実装内容

- 追加：ユーザログイン、新規登録ページを実装 https://github.com/O-H-K-N/walk-tour-vue/commit/f2edfc97c2cd83bab105a641a73fc8f506826e89 
  - ユーザー用のストアを作成

## 未実装内容

* ログイン失敗時の処理
* ログイン中にログインページや新規登録ページに遷移しないようにする処理

## できるようになること（ユーザ目線）

* ユーザ新規登録
* ログイン、ログアウト