### PR TITLE
ホットスポットとして地点のランキング表示を実装

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,7 +3,7 @@
     <Header></Header>
     <!-- ルートコンポーネントでページのメイン部分の表示 -->
     <v-container class="my-16">
-      <router-view class="mx-lg-16 my-lg-8"></router-view>
+      <router-view class="mx-lg-16 my-lg-8" style="color: #455A64;"></router-view>
     </v-container>
   </v-app>
 </template>

--- a/src/components/AutoComplete.vue
+++ b/src/components/AutoComplete.vue
@@ -1,9 +1,9 @@
 <template>
-  <div class="d-flex justify-center mt-5" style="margin: auto;" >
+  <div class="d-flex justify-center mt-5" style="margin: auto;" max-width="1000px" >
     <v-autocomplete
       v-model="value"
       :items="area_name"
-      label="地点名"
+      label="国名から検索しよう"
       no-data-text="データがありません"
       dense
     >

--- a/src/components/AutoComplete.vue
+++ b/src/components/AutoComplete.vue
@@ -6,10 +6,12 @@
       label="国名から検索しよう"
       no-data-text="データがありません"
       dense
+      solo
     >
     </v-autocomplete>
     <v-btn
-      class="ml-2"
+      class="ml-2 mt-1"
+      bottom
       outlined
       x-small
       fab

--- a/src/components/GoogleMap.vue
+++ b/src/components/GoogleMap.vue
@@ -7,13 +7,13 @@ export default {
   props: {
     area: Object,
     spots: Array,
+    spot: Object,
   },
   data() {
     return {
       latlng: [],
       // ダイアログの表示、非表示
       dialog: false,
-      spot: '',
       title: '',
       video_id: '',
       view_count: '',
@@ -44,11 +44,16 @@ export default {
       if (google) {
         clearInterval(timer);
 
+        // マーカー
         let marker = [];
+        let marker_2 = [];
         // クリック時に表示される情報ウィンドウ
         let infoWindowSpot = [];
+        let infoWindowSpot_2 = [];
         // カーソルホバー時に表示される情報ウィンドウ
         let infoWindowHover = [];
+        let infoWindowHover_2 = [];
+
         const standardIcon = "http://maps.google.co.jp/mapfiles/ms/icons/blue-dot.png"
         const focusIcon = "http://maps.google.co.jp/mapfiles/ms/icons/yellow-dot.png"
 
@@ -84,61 +89,129 @@ export default {
 
         // エリア内の各地点にマーカーを立てる
         for (let i = 0; i < this.spots.length; i++) {
-          // 地点の緯度経度
-          let spotLatLng = { lat: Number(this.spots[i].lat), lng: Number(this.spots[i].lng) };
-          // 地点にマーカーをたてる
-          marker[i] = new google.maps.Marker({
-            position: spotLatLng,
-            map,
-            icon: standardIcon,
-            animation: google.maps.Animation.DROP,
-          });
-          // マーカークリック時に動画の情報ウィンドウを表示
-          marker[i].addListener("click", () => {
-            // 開かれている情報ウィンドウがあれば閉じる処理
-            if (this.currentInfoWindow) {
-              this.currentInfoWindow.close();
-            };
-            // アクティブ状態のマーカーがあれば行う処理
-            if (this.focusMarker) {
-              // アクティブ中のマーカーを通常iconに戻す
-              this.focusMarker.setIcon({
-                url: standardIcon,
-              });
-              // アクティブ中のマーカーのバウンドを止める
-              this.focusMarker.setAnimation(
-                null
-              );
-            }
-            // アクティブ中のマーカーのみ色を変更する
-            marker[i].setIcon({
-              url: focusIcon,
+          // spotIdを引き継いでおり（ホットスポットからの遷移であり）、 APIで取得した地点の中で同じものであれば
+          if(this.spots[i] == this.spot) {
+            marker = new google.maps.Marker({
+              position: { lat: Number(this.spot.lat), lng: Number(this.spot.lng) },
+              map,
+              icon: focusIcon,
+              animation: google.maps.Animation.BOUNCE,
             });
-            // アクティブ中のマーカーのみバウンドさせる
-            marker[i].setAnimation(
-              google.maps.Animation.BOUNCE
-            );
+            infoWindowSpot = new google.maps.InfoWindow({
+              content: `<div class="mb-0"><h2>${this.spot.name}</h2></div>`
+            });
+            infoWindowHover = new google.maps.InfoWindow({
+              content: `<div class="mb-0"><h2>${this.spots[i].name}</h2></div>`
+            });
             // 情報ウィンドウを固定で表示する
-            infoWindowSpot[i].open(map, marker[i]);
-            this.getVideo(marker[i], infoWindowSpot[i],this.spots[i], this.area)
-          });
-          // マーカーにマウスオーバー時に地点名の情報ウィンドウを表示
-          marker[i].addListener("mouseover", () => {
-            infoWindowHover[i].open(map, marker[i]);
-          });
-          // マーカーからマウスアウトした時に地点名の情報ウィンドウを非表示
-          marker[i].addListener("mouseout", () => {
-            infoWindowHover[i].close(map, marker[i]);
-          });
-          // 情報ウィンドウ内に国名を表示
-          infoWindowHover[i] = new google.maps.InfoWindow({
-            content: `<div class="mb-0"><h2>${this.spots[i].name}</h2></div>`
-          });
-          // 情報ウィンドウ内に国名を表示
-          infoWindowSpot[i] = new google.maps.InfoWindow({
-            content: `<div class="mb-0"><h2>${this.spots[i].name}</h2></div>`
-          });
-        }
+            infoWindowSpot.open(map, marker);
+            // マーカーをアクティブ状態にする
+            this.focusMarker = marker;
+            // マーカーの情報ウィンドウに印をつける
+            this.currentInfoWindow = infoWindowSpot;
+            // マーカーにマウスオーバー時に地点名の情報ウィンドウを表示
+            marker.addListener("mouseover", () => {
+              infoWindowHover.open(map, marker);
+            });
+            // マーカーからマウスアウトした時に地点名の情報ウィンドウを非表示
+            marker.addListener("mouseout", () => {
+              infoWindowHover.close(map, marker);
+            });
+
+            marker.addListener("click", () => {
+              // 開かれている情報ウィンドウがあれば閉じる処理
+              if (this.currentInfoWindow) {
+                this.currentInfoWindow.close();
+              };
+              // アクティブ状態のマーカーがあれば行う処理
+              if (this.focusMarker) {
+                // アクティブ中のマーカーを通常iconに戻す
+                this.focusMarker.setIcon({
+                  url: standardIcon,
+                });
+                // アクティブ中のマーカーのバウンドを止める
+                this.focusMarker.setAnimation(
+                  null
+                );
+              }
+              // アクティブ中のマーカーのみ色を変更する
+              marker.setIcon({
+                url: focusIcon,
+              });
+              // アクティブ中のマーカーのみバウンドさせる
+              marker.setAnimation(
+                google.maps.Animation.BOUNCE
+              );
+              // 情報ウィンドウを固定で表示する
+              infoWindowSpot.open(map, marker);
+              // 地点に関する動画一覧ページに遷移する処理
+              this.getVideo(marker, infoWindowSpot,this.spot, this.area);
+              // マーカー(地点)がクリックされた時にクリック数が+1カウントされる
+              this.clickCount(this.spot, this.area);
+            });
+
+          } else {
+            // 地点の緯度経度
+            let spotLatLng = { lat: Number(this.spots[i].lat), lng: Number(this.spots[i].lng) };
+            // 地点にマーカーをたてる
+            marker_2[i] = new google.maps.Marker({
+              position: spotLatLng,
+              map,
+              icon: standardIcon,
+              animation: google.maps.Animation.DROP,
+            });
+
+            // マーカークリック時に動画の情報ウィンドウを表示
+            marker_2[i].addListener("click", () => {
+              // 開かれている情報ウィンドウがあれば閉じる処理
+              if (this.currentInfoWindow) {
+                this.currentInfoWindow.close();
+              };
+              // アクティブ状態のマーカーがあれば行う処理
+              if (this.focusMarker) {
+                // アクティブ中のマーカーを通常iconに戻す
+                this.focusMarker.setIcon({
+                  url: standardIcon,
+                });
+                // アクティブ中のマーカーのバウンドを止める
+                this.focusMarker.setAnimation(
+                  null
+                );
+              }
+              // アクティブ中のマーカーのみ色を変更する
+              marker_2[i].setIcon({
+                url: focusIcon,
+              });
+              // アクティブ中のマーカーのみバウンドさせる
+              marker_2[i].setAnimation(
+                google.maps.Animation.BOUNCE
+              );
+              // 情報ウィンドウを固定で表示する
+              infoWindowSpot_2[i].open(map, marker_2[i]);
+              // 地点に関する動画一覧ページに遷移する処理
+              this.getVideo(marker_2[i], infoWindowSpot_2[i],this.spots[i], this.area);
+              // マーカー(地点)がクリックされた時にクリック数が+1カウントされる
+              this.clickCount(this.spots[i], this.area);
+            });
+
+            // マーカーにマウスオーバー時に地点名の情報ウィンドウを表示
+            marker_2[i].addListener("mouseover", () => {
+              infoWindowHover_2[i].open(map, marker_2[i]);
+            });
+            // マーカーからマウスアウトした時に地点名の情報ウィンドウを非表示
+            marker_2[i].addListener("mouseout", () => {
+              infoWindowHover_2[i].close(map, marker_2[i]);
+            });
+            // 情報ウィンドウ内に国名を表示
+            infoWindowHover_2[i] = new google.maps.InfoWindow({
+              content: `<div class="mb-0"><h2>${this.spots[i].name}</h2></div>`
+            });
+            // 情報ウィンドウ内に国名を表示
+            infoWindowSpot_2[i] = new google.maps.InfoWindow({
+              content: `<div class="mb-0"><h2>${this.spots[i].name}</h2></div>`
+            });
+          };
+        };
       }
     }, 500);
   },
@@ -146,28 +219,14 @@ export default {
     // 地点に関する動画一覧ページに遷移する処理
     getVideo(marker, infoWindow, spot, area) {
       // マーカーをアクティブ状態にする
-      this.focusMarker = marker
+      this.focusMarker = marker;
       // マーカーの情報ウィンドウに印をつける
-      this.currentInfoWindow = infoWindow
+      this.currentInfoWindow = infoWindow;
+      // マーカー(地点)がクリックされた時にクリック数が+1カウントされる
       this.$emit("get-video", spot, area);
     },
-    openDialog(video, spot) {
-      this.dialog = true;
-      this.spot = spot
-      this.title = video.title;
-      this.video_id = video.video_id;
-      this.view_count = video.view_count;
-      this.published_at = video.published_at;
-      this.urlForEmbedVideo = `https://www.youtube.com/embed/${this.video_id}`;
-      // this.urlForPlayYoutubeApp = `https://www.youtube.com/watch?v=${this.video_id}`;
-    },
-    resetDialog() {
-      this.dialog = false;
-      this.title = ''
-      this.video_id = ''
-      this.description = ''
-      this.view_count = ''
-      this.urlForEmbedVideo = ''
+    clickCount(spot, area) {
+      this.$emit("click-count", spot, area);
     },
   }
 };

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -9,7 +9,7 @@
     >
       <!-- ヘッダータイトル -->
       <v-icon color="blue-grey lighten-1">
-        WALKTOUR
+        VtourHub
       </v-icon>
       <v-spacer></v-spacer>
       <!-- メニューアイコン -->

--- a/src/components/HomeRanking.vue
+++ b/src/components/HomeRanking.vue
@@ -1,0 +1,210 @@
+<template>
+  <div>
+    <router-link to="/spotRanking" style="color: #455A64; text-decoration: none;">
+      <h2 class="mb-1 d-flex align-center justify-center">
+        <v-icon left bottom>mdi-map-marker-outline</v-icon>
+        ホットスポット
+      </h2>
+    </router-link>
+    <v-divider class="mb-2"></v-divider>
+    <v-row>
+      <v-col cols="12" sm="12" md="4" lg="4" class="my-1">
+        <v-hover v-slot="{ hover }">
+          <v-card  :elevation="hover ? 12 : 2" max-width="500px" style="margin: auto;">
+            <v-img :src="firstVideo.thumbnail" alt="サムネイル"  @click="openDialog(firstArea, firstSpot, firstVideo);" style="cursor: pointer"></v-img>
+            <div class="d-flex justify-space-between">
+              <v-list-item>
+                <v-list-item-content>
+                  <v-list-item-title>{{ firstSpot.name }}</v-list-item-title>
+                  <v-list-item-subtitle class="mt-1">{{ firstArea.name }}</v-list-item-subtitle>
+                </v-list-item-content>
+              </v-list-item>
+              <v-card-actions>
+                <v-btn color="blue darken-1 align-center" outlined  @click="setSpot(firstArea, firstSpot)">他の動画を見る</v-btn>
+              </v-card-actions>
+            </div>
+          </v-card>
+        </v-hover>
+      </v-col>
+      <v-col cols="12" sm="12" md="4" lg="4" class="my-1">
+        <v-hover v-slot="{ hover }">
+          <v-card  :elevation="hover ? 12 : 2" max-width="500px" style="margin: auto;">
+            <v-img :src="secondVideo.thumbnail" alt="サムネイル"  @click="openDialog(secondArea, secondSpot, secondVideo);" style="cursor: pointer"></v-img>
+            <div class="d-flex justify-space-between">
+              <v-list-item>
+                <v-list-item-content>
+                  <v-list-item-title>{{ secondSpot.name }}</v-list-item-title>
+                  <v-list-item-subtitle class="mt-1">{{ secondArea.name }}</v-list-item-subtitle>
+                </v-list-item-content>
+              </v-list-item>
+              <v-card-actions>
+                <v-btn color="blue darken-1" outlined  @click="setSpot(secondArea, secondSpot)">他の動画を見る</v-btn>
+              </v-card-actions>
+            </div>
+          </v-card>
+        </v-hover>
+      </v-col>
+      <v-col cols="12" sm="12" md="4" lg="4" class="my-1">
+        <v-hover v-slot="{ hover }">
+          <v-card  :elevation="hover ? 12 : 2" max-width="500px" style="margin: auto;">
+            <v-img :src="thirdVideo.thumbnail" alt="サムネイル"  @click="openDialog(thirdArea, thirdSpot, thirdVideo);" style="cursor: pointer"></v-img>
+            <div class="d-flex justify-space-between">
+              <v-list-item>
+                <v-list-item-content>
+                  <v-list-item-title>{{ thirdSpot.name }}</v-list-item-title>
+                  <v-list-item-subtitle class="mt-1">{{ thirdArea.name }}</v-list-item-subtitle>
+                </v-list-item-content>
+              </v-list-item>
+              <v-card-actions>
+                <v-btn color="blue darken-1" outlined  @click="setSpot(thirdArea, thirdSpot)">他の動画を見る</v-btn>
+              </v-card-actions>
+            </div>
+          </v-card>
+        </v-hover>
+      </v-col>
+    </v-row>
+
+    <!-- ダイアログボックス -->
+    <v-dialog v-model="dialog" max-width="1200px">
+      <v-card>
+        <v-col>
+          <v-responsive :aspect-ratio="16/9">
+            <iframe
+              width="100%"
+              height="100%"
+              :src="urlForEmbedVideo"
+              frameborder="0"
+              autoplay
+              allowfullscreen
+              modestbranding="1"
+            ></iframe>
+          </v-responsive>
+        </v-col>
+        <v-card-subtitle class="py-0 font-weight-bold secondary--text">{{ title }}</v-card-subtitle>
+        <v-card-subtitle class="my-0 pb-1">{{ view_count.toLocaleString() }}回視聴・{{ published_at }}</v-card-subtitle>
+        <v-space></v-space>
+        <v-col class="d-flex justify-center pt-0">
+          <v-btn
+            color="blue darken-1"
+            outlined
+            @click="setSpot(area, spot)"
+          >
+            <v-icon left>mdi-video</v-icon>
+            {{ spot.name }}のVtour動画一覧
+          </v-btn>
+        </v-col>
+        <v-divider></v-divider>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn
+            color="blue darken-1"
+            text
+            @click="resetDialog()"
+          >
+            CLOSE
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </div>
+</template>
+
+<script>
+import axios from '../plugins/axios'
+
+export default {
+  data() {
+    return {
+      // 地点ランキング上位三つの各オブジェクト
+      firstSpot: {},
+      secondSpot: {},
+      thirdSpot: {},
+      firstArea: {},
+      secondArea: {},
+      thirdArea: {},
+      firstVideo: {},
+      secondVideo: {},
+      thirdVideo: {},
+      // ダイアログに渡すdata
+      dialog: false,
+      title: '',
+      video_id: '',
+      view_count: '',
+      published_at: '',
+      urlForEmbedVideo: '',
+      area: [],
+      spot: [],
+    }
+  },
+  created() {
+    this.getSpot();
+  },
+  // データの変更
+  watch: {
+    // ダイアログの状態を監視（表示、非表示の切り替えと同時にdataをリセット）
+    dialog() {
+      if (!this.dialog) {
+        this.resetDialog()
+      }
+    },
+  },
+  methods: {
+    // すべての地点とその国、動画を取得
+    getSpot() {
+      axios.get('/all_spot')
+      .then( res => {
+        this.firstSpot = res.data.spots[0]
+        this.secondSpot = res.data.spots[1]
+        this.thirdSpot = res.data.spots[2]
+        this.firstArea = res.data.areas[0]
+        this.secondArea = res.data.areas[1]
+        this.thirdArea = res.data.areas[2]
+        this.firstVideo = res.data.videos[0]
+        this.secondVideo = res.data.videos[1]
+        this.thirdVideo = res.data.videos[2]
+      })
+    },
+    // クリックしたカードの地点の国の詳細ページに遷移させる処理
+    setSpot(area, spot) {
+      // 地点のカウント数を+1する
+      this.clickCount(spot, area)
+      axios.get(`/countries/${spot.country_id}/spots`)
+      .then( res => {
+        this.$router.push({ name: "SpotResult", params: { id: res.data.area.id, spotId: spot.id} });
+      })
+    },
+    // カードがクリックされた時に+1カウントされる
+    clickCount(spot, area) {
+      axios.get(`/countries/${area.id}/spots/${spot.id}/edit`)
+      .then(res => {
+        console.log(res.data.status);
+      })
+      .catch(error => {
+        console.log(error);
+      })
+    },
+    // ダイアログの表示
+    openDialog(area, spot, video) {
+      this.dialog = true;
+      this.title = video.title;
+      this.video_id = video.video_id;
+      this.view_count = video.view_count;
+      this.published_at = video.published_at;
+      this.urlForEmbedVideo = `https://www.youtube.com/embed/${this.video_id}`;
+      this.area =  area;
+      this.spot =  spot;
+    },
+    // ダイアログを非表示にしdataを空にする
+    resetDialog() {
+      this.dialog = false;
+      this.title = '';
+      this.video_id = '';
+      this.description = '';
+      this.view_count = '';
+      this.urlForEmbedVideo = '';
+      this.area =  [];
+      this.spot = [];
+    },
+  }
+}
+</script>

--- a/src/components/HomeSpotRanking.vue
+++ b/src/components/HomeSpotRanking.vue
@@ -2,12 +2,14 @@
   <div>
     <router-link to="/spotRanking" style="color: #455A64; text-decoration: none;">
       <h2 class="mb-1 d-flex align-center justify-center">
-        <v-icon left bottom>mdi-map-marker-outline</v-icon>
+        <v-icon left bottom>mdi-fire</v-icon>
         ホットスポット
       </h2>
     </router-link>
     <v-divider class="mb-2"></v-divider>
-    <v-row>
+
+    <!-- 画面幅がxs,smの時に表示 -->
+    <v-row class="mx-auto hidden-md-and-up">
       <v-col cols="12" sm="12" md="4" lg="4" class="my-1">
         <v-hover v-slot="{ hover }">
           <v-card  :elevation="hover ? 12 : 2" max-width="500px" style="margin: auto;">
@@ -64,6 +66,31 @@
       </v-col>
     </v-row>
 
+    <!-- 画面幅がmd, lg, xlで表示 -->
+    <v-sheet class="mx-auto hidden-sm-and-down" max-width="1400">
+      <v-slide-group class="pa-4" active-class="success" show-arrows  height="400">
+        <v-slide-item
+          v-for="spotDetail in spotDetails" :key="spotDetail.id">
+          <v-hover v-slot="{ hover }">
+            <v-card  :elevation="hover ? 12 : 2" width="300" class="ma-2" style="margin: auto;">
+              <v-img :src="spotDetail.video.thumbnail" alt="サムネイル"  @click="openDialog(spotDetail.area, spotDetail.spot, spotDetail.video);" style="cursor: pointer"></v-img>
+              <div class="d-flex justify-space-between">
+                <v-list-item>
+                  <v-list-item-content>
+                    <v-list-item-title>{{ spotDetail.spot.name }}</v-list-item-title>
+                    <v-list-item-subtitle class="mt-1">{{ spotDetail.area.name }}</v-list-item-subtitle>
+                  </v-list-item-content>
+                </v-list-item>
+                <v-card-actions>
+                  <v-btn color="blue darken-1 align-center" text  @click="setSpot(spotDetail.area, spotDetail.spot)">行ってみる！</v-btn>
+                </v-card-actions>
+              </div>
+            </v-card>
+          </v-hover>
+        </v-slide-item>
+      </v-slide-group>
+    </v-sheet>
+
     <!-- ダイアログボックス -->
     <v-dialog v-model="dialog" max-width="1200px">
       <v-card>
@@ -82,7 +109,7 @@
         </v-col>
         <v-card-subtitle class="py-0 font-weight-bold secondary--text">{{ title }}</v-card-subtitle>
         <v-card-subtitle class="my-0 pb-1">{{ view_count.toLocaleString() }}回視聴・{{ published_at }}</v-card-subtitle>
-        <v-space></v-space>
+        <v-spacer></v-spacer>
         <v-col class="d-flex justify-center pt-0">
           <v-btn
             color="blue darken-1"
@@ -125,6 +152,8 @@ export default {
       firstVideo: {},
       secondVideo: {},
       thirdVideo: {},
+      // すべての地点その国、動画オブジェクトを格納する配列
+      spotDetails: [],
       // ダイアログに渡すdata
       dialog: false,
       title: '',
@@ -132,8 +161,8 @@ export default {
       view_count: '',
       published_at: '',
       urlForEmbedVideo: '',
-      area: [],
-      spot: [],
+      area: {},
+      spot: {},
     }
   },
   created() {
@@ -153,6 +182,9 @@ export default {
     getSpot() {
       axios.get('/all_spot')
       .then( res => {
+        for(let i = 0; i < 12; i++) {
+          this.spotDetails.push( {id: i, spot: res.data.spots[i], area: res.data.areas[i], video: res.data.videos[i]} )
+        };
         this.firstSpot = res.data.spots[0]
         this.secondSpot = res.data.spots[1]
         this.thirdSpot = res.data.spots[2]

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -72,6 +72,7 @@ export default {
       // 未ログインのメニューリスト
       items: [
         { title: 'トップページ', icon: 'mdi-home-outline', url: '/' },
+        { title: 'ホットスポット', icon: 'mdi-fire', url: '/spotRanking' },
         { title: 'ログイン', icon: 'mdi-login', url: '/login' },
         { title: '新規登録', icon: 'mdi-account-plus', url: '/register' },
       ],

--- a/src/components/Video.vue
+++ b/src/components/Video.vue
@@ -1,9 +1,9 @@
 <template>
   <div>
-    <v-row>
+    <v-row style="max-width: 1200px; margin: auto;">
       <v-col v-for="video in videos" :key="video.videoId" cols="12" sm="6" md="6" lg="4" class="my-1">
         <v-hover v-slot="{ hover }">
-          <v-card :elevation="hover ? 12 : 2" max-width="500px" style="margin: auto;">
+          <v-card :elevation="hover ? 12 : 2" max-width="400px" style="margin: auto;">
             <v-img :src="video.thumbnail" alt="サムネイル"  @click="openDialog(video);" style="cursor: pointer"></v-img>
             <v-list-item>
               <v-list-item-content>

--- a/src/components/Video.vue
+++ b/src/components/Video.vue
@@ -2,20 +2,22 @@
   <div>
     <v-row>
       <v-col v-for="video in videos" :key="video.videoId" cols="12" sm="6" md="6" lg="4" class="my-1">
-        <v-card>
-          <v-img :src="video.thumbnail" alt="サムネイル"  @click="openDialog(video);" style="cursor: pointer"></v-img>
-          <v-list-item>
-            <v-list-item-content>
-              <v-list-item-title>{{ video.title }}</v-list-item-title>
-              <v-list-item-subtitle class="mt-1">{{ video.view_count.toLocaleString() }}回視聴・{{ video.published_at }}</v-list-item-subtitle>
-            </v-list-item-content>
-          </v-list-item>
-        </v-card>
+        <v-hover v-slot="{ hover }">
+          <v-card :elevation="hover ? 12 : 2" max-width="500px" style="margin: auto;">
+            <v-img :src="video.thumbnail" alt="サムネイル"  @click="openDialog(video);" style="cursor: pointer"></v-img>
+            <v-list-item>
+              <v-list-item-content>
+                <v-list-item-title>{{ video.title }}</v-list-item-title>
+                <v-list-item-subtitle class="mt-1">{{ video.view_count.toLocaleString() }}回視聴・{{ video.published_at }}</v-list-item-subtitle>
+              </v-list-item-content>
+            </v-list-item>
+          </v-card>
+        </v-hover>
       </v-col>
     </v-row>
 
     <!-- ダイアログボックス -->
-    <v-dialog v-model="dialog">
+    <v-dialog v-model="dialog" max-width="1300px">
       <v-card>
         <v-col>
           <v-responsive :aspect-ratio="16/9">
@@ -31,13 +33,13 @@
           </v-responsive>
         </v-col>
         <v-card-subtitle class="py-0 font-weight-bold secondary--text">{{ title }}</v-card-subtitle>
-        <v-card-subtitle class="my-0 pb-1">{{ view_count }}回視聴・{{ published_at }}</v-card-subtitle>
+        <v-card-subtitle class="my-0 pb-1">{{ view_count.toLocaleString() }}回視聴・{{ published_at }}</v-card-subtitle>
         <v-divider></v-divider>
         <v-card-actions>
           <v-spacer></v-spacer>
           <v-btn
             color="blue darken-1"
-            outlined
+            text
             @click="resetDialog()"
           >
             CLOSE

--- a/src/components/WorldMap.vue
+++ b/src/components/WorldMap.vue
@@ -1,9 +1,16 @@
 <template>
-  <div class="d-flex justify-center mt-5" style="margin: auto;" >
-    <div
-      id="vmap"
-      style="width: 900px; height: 600px; margin: auto;"
-    ></div>
+  <div>
+    <h2 class="mb-1 d-flex align-center justify-center">
+      <v-icon left bottom>mdi-map-outline</v-icon>
+      地図から探す
+    </h2>
+    <v-divider class="mb-2"></v-divider>
+    <div class="d-flex justify-center mt-5" style="margin: auto;" >
+      <div
+        id="vmap"
+        style="width: 900px; height: 600px; margin: auto;"
+      ></div>
+    </div>
   </div>
 </template>
 
@@ -51,8 +58,21 @@ export default {
     },
     // クリックされた国の詳細ページに遷移させる処理
     setArea(iso) {
-      this.$emit("set-area", iso);
-    }
+      // iso二桁コードをもとにクリックされた国を取得
+      axios.get('/countries', {
+        params: {
+          iso: iso
+        }
+      })
+      .then( res => {
+        this.$router.push({ name: "SpotResult", params: { id: res.data.id } });
+      })
+      .catch( res => {
+        // 地点登録がない場合は遷移せずアラートで表示
+        var message = res.response.data.name + 'の登録情報はありません';
+        alert(message);
+      });
+    },
   }
 }
 </script>

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -1,54 +1,20 @@
 <template>
-  <div>
+  <div style="color: #455A64;">
     <!-- 地点から動画を表示させるための検索窓 -->
     <AutoComplete></AutoComplete>
     <!-- jqvmapで世界地図を表示 -->
-    <WorldMap @set-area="setArea"></WorldMap>
+    <WorldMap></WorldMap>
+    <!-- ホットスポットの上位三つを表示 -->
+    <HomeRanking></HomeRanking>
   </div>
 </template>
 
 <script>
-import axios from '../plugins/axios'
-import WorldMap from '../components/WorldMap.vue'
 import AutoComplete from '../components/AutoComplete.vue'
+import WorldMap from '../components/WorldMap.vue'
+import HomeRanking from '../components/HomeRanking.vue'
 
 export default {
-  components: { WorldMap, AutoComplete },
-  data() {
-    return {
-      // ダイアログの表示、非表示
-      area: {},
-      spots: [],
-      dialog: false,
-    }
-  },
-  watch: {
-    // ダイアログの状態を監視（表示、非表示の切り替えと同時にdataをリセット）
-    dialog() {
-      if (!this.dialog) {
-        this.resetDialog();
-      }
-    },
-  },
-  methods: {
-    // クリックした国に関するダイアログが表示される
-    setArea(iso) {
-      // iso二桁コードをもとにクリックされた国を取得
-      axios.get('/countries', {
-        params: {
-          iso: iso
-        }
-      })
-      .then( res => {
-        this.area = res.data;
-        this.$router.push({ name: "SpotResult", params: { id: this.area.id } });
-      })
-      .catch( res => {
-        // 地点登録がない場合は遷移せずアラートで表示
-        var message = res.response.data.name + 'の登録情報はありません';
-        alert(message);
-      });
-    },
-  }
+  components: { WorldMap, AutoComplete, HomeRanking },
 }
 </script>

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -12,7 +12,7 @@
 <script>
 import AutoComplete from '../components/AutoComplete.vue'
 import WorldMap from '../components/WorldMap.vue'
-import HomeRanking from '../components/HomeRanking.vue'
+import HomeRanking from '../components/HomeSpotRanking.vue'
 
 export default {
   components: { WorldMap, AutoComplete, HomeRanking },

--- a/src/pages/SpotRanking.vue
+++ b/src/pages/SpotRanking.vue
@@ -1,0 +1,169 @@
+<template>
+  <div>
+    <h2 class="mb-1 d-flex align-center justify-center">
+      <v-icon left bottom>mdi-fire</v-icon>
+      ホットスポット
+    </h2>
+    <v-divider class="mb-2" style="max-width: 700px; margin: auto;"></v-divider>
+    <div class="d-flex justify-center">
+      <v-row>
+        <v-col v-for="spotDetail in spotDetails" :key="spotDetail.id" cols="12">
+          <v-hover v-slot="{ hover }">
+            <v-card  :elevation="hover ? 12 : 2" max-width="500px" style="margin: auto;">
+              <div class="d-flex justify-space-between">
+                <div class="d-flex flex-column">
+                  <v-list-item>
+                    <v-list-item-content>
+                      <v-list-item-subtitle class="mb-2">過去{{ spotDetail.spot.click_count }}回の渡航歴</v-list-item-subtitle>
+                      <v-list-item-title>{{ spotDetail.spot.name }}</v-list-item-title>
+                      <v-list-item-subtitle>{{ spotDetail.area.name }}</v-list-item-subtitle>
+                    </v-list-item-content>
+                  </v-list-item>
+                  <v-divider></v-divider>
+                  <v-btn color="blue darken-1 align-center" class="hidden-sm-and-down" text @click="setSpot(spotDetail.area, spotDetail.spot)">行ってみる！</v-btn>
+                </div>
+                <v-img :src="spotDetail.video.thumbnail" alt="サムネイル"  @click="openDialog(spotDetail.area, spotDetail.spot, spotDetail.video);" class="hidden-sm-and-down" style="cursor: pointer"></v-img>
+                <v-card-actions class="hidden-md-and-up">
+                  <v-btn color="blue darken-1 align-center" text @click="setSpot(spotDetail.area, spotDetail.spot)">行ってみる</v-btn>
+                </v-card-actions>
+              </div>
+            </v-card>
+          </v-hover>
+        </v-col>
+      </v-row>
+    </div>
+
+    <!-- ダイアログボックス -->
+    <v-dialog v-model="dialog" max-width="1200px">
+      <v-card>
+        <v-col>
+          <v-responsive :aspect-ratio="16/9">
+            <iframe
+              width="100%"
+              height="100%"
+              :src="urlForEmbedVideo"
+              frameborder="0"
+              autoplay
+              allowfullscreen
+              modestbranding="1"
+            ></iframe>
+          </v-responsive>
+        </v-col>
+        <v-card-subtitle class="py-0 font-weight-bold secondary--text">{{ title }}</v-card-subtitle>
+        <v-card-subtitle class="my-0 pb-1">{{ view_count.toLocaleString() }}回視聴・{{ published_at }}</v-card-subtitle>
+        <v-spacer></v-spacer>
+        <v-col class="d-flex justify-center pt-0">
+          <v-btn
+            color="blue darken-1"
+            outlined
+            @click="setSpot(area, spot)"
+          >
+            <v-icon left>mdi-video</v-icon>
+            {{ spot.name }}のVtour動画一覧
+          </v-btn>
+        </v-col>
+        <v-divider></v-divider>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn
+            color="blue darken-1"
+            text
+            @click="resetDialog()"
+          >
+            CLOSE
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </div>
+</template>
+
+<script>
+import axios from '../plugins/axios'
+
+export default {
+  data() {
+    return {
+      // すべての地点その国、動画オブジェクトを格納する配列
+      spotDetails: [],
+      // ダイアログに渡すdata
+      dialog: false,
+      title: '',
+      video_id: '',
+      view_count: '',
+      published_at: '',
+      urlForEmbedVideo: '',
+      area: {},
+      spot: {},
+    }
+  },
+  created() {
+    this.getSpot();
+  },
+  // データの変更
+  watch: {
+    // ダイアログの状態を監視（表示、非表示の切り替えと同時にdataをリセット）
+    dialog() {
+      if (!this.dialog) {
+        this.resetDialog()
+      }
+    },
+  },
+  methods: {
+    // すべての地点とその国、動画を取得
+    getSpot() {
+      axios.get('/all_spot')
+      .then( res => {
+        for(let i = 0; i < res.data.spots.length; i++) {
+          this.spotDetails.push( {id: i, spot: res.data.spots[i], area: res.data.areas[i], video: res.data.videos[i]} )
+        };
+      })
+    },
+    // クリックしたカードの地点の国の詳細ページに遷移させる処理
+    setSpot(area, spot) {
+      // 地点のカウント数を+1する
+      this.clickCount(spot, area)
+      axios.get(`/countries/${spot.country_id}/spots`)
+      .then( res => {
+        this.$router.push({ name: "SpotResult", params: { id: res.data.area.id, spotId: spot.id} });
+      })
+    },
+    // カードがクリックされた時に+1カウントされる
+    clickCount(spot, area) {
+      axios.get(`/countries/${area.id}/spots/${spot.id}/edit`)
+      .then(res => {
+        console.log(res.data.status);
+      })
+      .catch(error => {
+        console.log(error);
+      })
+    },
+    // ダイアログの表示
+    openDialog(area, spot, video) {
+      this.dialog = true;
+      this.title = video.title;
+      this.video_id = video.video_id;
+      this.view_count = video.view_count;
+      this.published_at = video.published_at;
+      this.urlForEmbedVideo = `https://www.youtube.com/embed/${this.video_id}`;
+      this.area =  area;
+      this.spot =  spot;
+    },
+    // ダイアログを非表示にしdataを空にする
+    resetDialog() {
+      this.dialog = false;
+      this.title = '';
+      this.video_id = '';
+      this.description = '';
+      this.view_count = '';
+      this.urlForEmbedVideo = '';
+      this.area =  [];
+      this.spot = [];
+    },
+  }
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/src/pages/SpotResult.vue
+++ b/src/pages/SpotResult.vue
@@ -1,7 +1,10 @@
 <template>
   <div>
-    <h2>{{ area.name }}</h2>
-    <v-divider class="mb-2"></v-divider>
+    <h2 class="mb-1 d-flex align-center justify-center">
+      <v-icon left bottom>mdi-earth</v-icon>
+      {{ area.name }}
+    </h2>
+    <v-divider class="mb-2" style="max-width: 700px; margin: auto;"></v-divider>
     <v-row no-gutters class="my-5">
       <v-col>
         <GoogleMap :area="area" :spots="spots" :spot="spot" @get-video="getVideo" @click-count="clickCount"></GoogleMap>
@@ -9,21 +12,24 @@
     </v-row>
 
     <template v-if="videos.length != 0">
-      <v-row>
-        <v-col lg="6" class="d-flex align-end">
-          <h3>{{ spot_name }}</h3>
+      <v-row style="max-width: 1200px; margin: auto;">
+        <v-col lg="6" class="d-flex align-end pb-0">
+          <h3 class="mb-2 d-flex align-center justify-center">
+            <v-icon left bottom>mdi-map-marker</v-icon>
+            {{ spot_name }}
+          </h3>
         </v-col>
-        <v-col lg="6">
+        <v-col lg="6 pb-0">
           <v-tabs right v-model="currentTab">
             <v-tab @click="viewOrder(videos)" :value="'viewTab'">閲覧順</v-tab>
             <v-tab @click="newOrder(videos)">新着順</v-tab>
           </v-tabs>
         </v-col>
       </v-row>
-      <v-divider class="mb-2"></v-divider>
+      <v-divider style="max-width: 1200px; margin: auto;"></v-divider>
     </template>
     <template v-else>
-      <v-chip label large class="mt-10 d-flex justify-center" color="light-blue lighten-1" text-color="white">
+      <v-chip label large class="mt-10 d-flex justify-center" color="light-blue lighten-1" text-color="white" style="max-width: 700px; margin: auto;">
         <v-icon left>mdi-cursor-default-click-outline</v-icon>
         マーカーをクリックしてください
       </v-chip>

--- a/src/pages/SpotResult.vue
+++ b/src/pages/SpotResult.vue
@@ -1,17 +1,17 @@
 <template>
-  <div style="color: #455A64;">
+  <div>
     <h2>{{ area.name }}</h2>
     <v-divider class="mb-2"></v-divider>
     <v-row no-gutters class="my-5">
       <v-col>
-        <GoogleMap :area="area" :spots="spots" @get-video="getVideo"></GoogleMap>
+        <GoogleMap :area="area" :spots="spots" :spot="spot" @get-video="getVideo" @click-count="clickCount"></GoogleMap>
       </v-col>
     </v-row>
 
     <template v-if="videos.length != 0">
       <v-row>
         <v-col lg="6" class="d-flex align-end">
-          <h3>{{ spot.name }}</h3>
+          <h3>{{ spot_name }}</h3>
         </v-col>
         <v-col lg="6">
           <v-tabs right v-model="currentTab">
@@ -24,9 +24,7 @@
     </template>
     <template v-else>
       <v-chip label large class="mt-10 d-flex justify-center" color="light-blue lighten-1" text-color="white">
-        <v-icon left>
-          mdi-cursor-default-click-outline
-        </v-icon>
+        <v-icon left>mdi-cursor-default-click-outline</v-icon>
         マーカーをクリックしてください
       </v-chip>
     </template>
@@ -41,20 +39,29 @@ import Video from '../components/Video.vue'
 
 export default {
   components: { GoogleMap, Video },
-  props: ["id"],
+  props: {
+    id: Number,
+    spotId: Number
+  },
   data() {
     return {
       area: {},
       spots: [],
-      spot: [],
+      spot: {},
+      spot_name: '',
       videos: [],
       // タブのフォーカス
       currentTab: "viewTab",
     }
   },
   created() {
+    // spotIdを引き継いでいれば（ホットスポットからの遷移であれば）spotIdに関する動画も一覧表示する
+    if(this.spotId == undefined) {
+      this.setSpot()
+    } else {
+      this.setSpotAndVideo()
+    }
     // 立ち上がり時に国に関する地点を取得
-    this.setSpot()
   },
   methods: {
     // 国に関する地点を取得
@@ -73,7 +80,6 @@ export default {
     getVideo(spot, area) {
       // マーカークリックと同時に'閲覧順'にフォーカスを当てる
       this.currentTab = "viewTab"
-      this.spot = spot
       axios.get(`/many_video`, {
         params: {
           id: spot.id,
@@ -85,9 +91,43 @@ export default {
       })
       .then(res => {
         this.videos = res.data;
+        this.spot_name = spot.name
       })
       .catch(error => {
         console.log(error)
+      })
+    },
+    // 地点の表示と動画の一覧表示を同時に行う処理
+    setSpotAndVideo() {
+      axios.get(`/countries/${this.id}/spots`)
+      .then(res => {
+        this.area = res.data.area
+        this.spots = res.data.spots
+        let i = 0;
+        // APIで取得した地点の中でpropsで引き継いだ地点と同じものを探す
+        while (i < this.spots.length) {
+          if (this.spots[i].id == this.spotId) {
+            this.spot = this.spots[i]
+            break;
+          }
+          i++;
+        };
+        // propsで引き継いだ地点の動画を取得
+        this.getVideo(this.spot, this.area);
+      })
+      .catch(error => {
+        console.log(error)
+        this.$router.push({ name: "Home" })
+      })
+    },
+    // マーカー(地点)がクリックされた時に+1カウントされる
+    clickCount(spot, area) {
+      axios.get(`/countries/${area.id}/spots/${spot.id}/edit`)
+      .then(res => {
+        console.log(res.data.status);
+      })
+      .catch(error => {
+        console.log(error);
       })
     },
     // 動画を新着順に並び替える

--- a/src/pages/auth/Register.vue
+++ b/src/pages/auth/Register.vue
@@ -43,7 +43,7 @@
                 prepend-icon="mdi-lock-outline"
                 :append-icon="showPasswordConfirmation ? 'mdi-eye' : 'mdi-eye-off'"
                 :type="showPasswordConfirmation ? 'text' : 'password'"
-                label="パスワー確認"
+                label="パスワード確認"
                 placeholder="8〜12文字"
                 validate-on-blur
                 required

--- a/src/router.js
+++ b/src/router.js
@@ -3,6 +3,7 @@ import Router from "vue-router";
 import store from "./store"
 import Home from "./pages/Home.vue"
 import SpotResult from "./pages/SpotResult.vue"
+import SpotRanking from "./pages/SpotRanking.vue"
 import Login from "./pages/auth/Login.vue"
 import Register from "./pages/auth/Register.vue"
 
@@ -25,6 +26,9 @@ const router = new Router({
     },
     {
       path: "/register", component: Register, name: "Register",
+    },
+    {
+      path: "/spotRanking", component: SpotRanking, name: "SpotRanking",
     },
   ]
 })


### PR DESCRIPTION
## 実装内容

* 追加：Home画面で人気スポットを動画も合わせて三つ表示されるように実装 https://github.com/O-H-K-N/walk-tour-vue/pull/11/commits/379b616cdfcb5b4c7bcd83acc477788b5343fca8 
* 追加：地図、動画の表示幅を修正 https://github.com/O-H-K-N/walk-tour-vue/pull/11/commits/488d0f84155cd401d3ea0853463729a75b1d95ef 
* 修正：ホームでのスポットランキングの表示を、画面幅で動的に表示されるように修正 https://github.com/O-H-K-N/walk-tour-vue/pull/11/commits/b167a2ee47de718393af17df97089544c9235ce1 
* 追加：スポットランキングページを実装 https://github.com/O-H-K-N/walk-tour-vue/pull/11/commits/50addc6de5240e7dbcd8d8b982f037816cc12128 


## できるようになること（ユーザ目線）

* よくチェックされている地点をランキング形式でチェックできる
* ランキングカードから動画のダイアログを表示でき、すくに閲覧することができる
* ランキングカードの「行ってみる！」リンクから地点詳細ページに遷移できる
