### PR TITLE
お知らせページを実装

### DIFF
--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -73,6 +73,7 @@ export default {
       items: [
         { title: 'トップページ', icon: 'mdi-home-outline', url: '/' },
         { title: 'ホットスポット', icon: 'mdi-fire', url: '/spotRanking' },
+        { title: 'お知らせ', icon: 'mdi-information-outline', url: '/newsList' },
         // { title: 'スポットをリクエスト', icon: 'mdi-send-circle', url: '/spotRequest' },
         { title: 'ログイン', icon: 'mdi-login', url: '/login' },
         { title: '新規登録', icon: 'mdi-account-plus', url: '/register' },
@@ -81,6 +82,7 @@ export default {
       itemsLogin: [
         { title: 'トップページ', icon: 'mdi-home-outline', url: '/' },
         { title: 'ホットスポット', icon: 'mdi-fire', url: '/spotRanking' },
+        { title: 'お知らせ', icon: 'mdi-information-outline', url: '/newsList' },
         // { title: 'お気に入り地点', icon: 'mdi-heart-outline', url: '' },
         { title: 'スポットをリクエスト', icon: 'mdi-send-circle', url: '/spotRequest' },
         { title: 'ログアウト', icon: 'mdi-logout', action: "logout" },

--- a/src/pages/NewsList.vue
+++ b/src/pages/NewsList.vue
@@ -1,0 +1,60 @@
+<template>
+  <v-container class="my-16">
+    <h2 class="mb-1 d-flex align-center justify-center">
+      <v-icon left bottom>mdi-information-outline</v-icon>
+      お知らせ
+    </h2>
+    <v-divider class="mb-2" style="max-width: 700px; margin: auto;"></v-divider>
+
+    <v-simple-table style="max-width: 1000px; margin: auto;">
+      <template v-slot:default>
+        <thead>
+          <tr>
+            <th class="text-left">
+              更新日
+            </th>
+            <th class="text-left">
+              内容
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="item in newsLists"
+            :key="item.id"
+          >
+            <td>{{ item.created_at }}</td>
+            <td>{{ item.content }}</td>
+          </tr>
+        </tbody>
+      </template>
+    </v-simple-table>
+  </v-container>
+</template>
+
+<script>
+import axios from '../plugins/axios'
+
+export default {
+  data() {
+    return {
+      newsLists: {
+        created_at: '',
+        content: '',
+      }
+    }
+  },
+  created() {
+    // DB内のすべての国名を取得
+    this.getNews();
+  },
+  methods: {
+    getNews() {
+      axios.get('/news_lists')
+      .then( res => {
+        this.newsLists = res.data
+      })
+    },
+  }
+}
+</script>

--- a/src/router.js
+++ b/src/router.js
@@ -5,6 +5,7 @@ import Home from "./pages/Home.vue"
 import SpotResult from "./pages/SpotResult.vue"
 import SpotRanking from "./pages/SpotRanking.vue"
 import SpotRequest from "./pages/SpotRequest.vue"
+import NewsList from "./pages/NewsList.vue"
 import Login from "./pages/auth/Login.vue"
 import Register from "./pages/auth/Register.vue"
 
@@ -30,6 +31,9 @@ const router = new Router({
     },
     {
       path: "/spotRanking", component: SpotRanking, name: "SpotRanking",
+    },
+    {
+      path: "/newsList", component: NewsList, name: "NewsList"
     },
     {
       path: "/spotRequest", component: SpotRequest, name: "SpotRequest", meta: { requiredAuth: true }


### PR DESCRIPTION
## 実装内容

* 追加：お知らせページを実装 https://github.com/O-H-K-N/walk-tour-vue/pull/15/commits/cc3df2fcf381226c5be62641143f1acdf64013bb 

## できるようになること（ユーザ目線）
- ユーザは管理者が作成、追加したお知らせ情報を確認できる