### PR TITLE
お気に入り登録ボタンとお気に入り一覧ページ（マイページ）の実装

### DIFF
--- a/src/components/HomeSpotRanking.vue
+++ b/src/components/HomeSpotRanking.vue
@@ -2,7 +2,7 @@
   <div>
     <router-link to="/spotRanking" style="color: #455A64; text-decoration: none;">
       <h2 class="d-flex align-center justify-center">
-        <v-icon left bottom>mdi-fire</v-icon>
+        <v-icon left bottom color="red">mdi-fire</v-icon>
         ホットスポット
       </h2>
     </router-link>
@@ -10,7 +10,7 @@
 
     <!-- 画面幅がxs,smの時に表示 -->
     <v-row class="mx-auto hidden-md-and-up">
-      <v-col cols="12" sm="12" md="4" lg="4" class="">
+      <v-col cols="12" sm="12" md="4" lg="4">
         <v-hover v-slot="{ hover }">
           <v-card  :elevation="hover ? 12 : 2" max-width="500px" style="margin: auto;">
             <v-img :src="firstVideo.thumbnail" alt="サムネイル"  @click="openDialog(firstArea, firstSpot, firstVideo);" style="cursor: pointer"></v-img>
@@ -28,7 +28,7 @@
           </v-card>
         </v-hover>
       </v-col>
-      <v-col cols="12" sm="12" md="4" lg="4" class="">
+      <v-col cols="12" sm="12" md="4" lg="4">
         <v-hover v-slot="{ hover }">
           <v-card  :elevation="hover ? 12 : 2" max-width="500px" style="margin: auto;">
             <v-img :src="secondVideo.thumbnail" alt="サムネイル"  @click="openDialog(secondArea, secondSpot, secondVideo);" style="cursor: pointer"></v-img>

--- a/src/components/HomeSpotRanking.vue
+++ b/src/components/HomeSpotRanking.vue
@@ -8,58 +8,28 @@
 
     <!-- 画面幅がxs,smの時に表示 -->
     <v-row class="mx-auto mb-2 hidden-md-and-up">
-      <v-col cols="12" sm="12" md="4" lg="4">
+      <v-col v-for="spotDetail in smallLimitCount" :key="spotDetail.id" cols="12" sm="12" md="4" lg="4">
         <v-hover v-slot="{ hover }">
-          <v-card  :elevation="hover ? 12 : 2" max-width="400px" style="margin: auto;">
-            <v-img :src="firstVideo.thumbnail" alt="サムネイル"  @click="openDialog(firstArea, firstSpot, firstVideo);" style="cursor: pointer"></v-img>
+          <v-card :elevation="hover ? 12 : 2" max-width="400px" style="margin: auto;">
+            <v-img :src="spotDetail.video.thumbnail" alt="サムネイル"  @click="openDialog(spotDetail.area, spotDetail.spot, spotDetail.video);" style="cursor: pointer"></v-img>
+            <template v-if="authUser">
+              <v-btn v-if="spotDetail.heart == true" class="btn ma-2" fab small color="white" @click="unBookmark(spotDetail.id, spotDetail.spot.id)">
+                <v-icon color="pink">mdi-heart</v-icon>
+              </v-btn>
+              <v-btn v-else class="btn ma-2" fab small color="white" @click="bookmark(spotDetail.id, spotDetail.spot.id)">
+                <v-icon color="pink">mdi-heart-outline</v-icon>
+              </v-btn>
+            </template>
             <div class="d-flex justify-space-between">
               <v-list-item>
                 <v-list-item-content>
-                  <v-list-item-subtitle class="mb-2">ランキング第1位</v-list-item-subtitle>
-                  <v-list-item-title>{{ firstSpot.name }}</v-list-item-title>
-                  <v-list-item-subtitle class="mt-1">{{ firstArea.name }}</v-list-item-subtitle>
+                  <v-list-item-subtitle small>ランキング第{{ spotDetail.id + 1 }}位</v-list-item-subtitle>
+                  <v-list-item-title class="my-1">{{ spotDetail.spot.name }}</v-list-item-title>
+                  <v-list-item-subtitle>{{ spotDetail.area.name }}</v-list-item-subtitle>
                 </v-list-item-content>
               </v-list-item>
               <v-card-actions>
-                <v-btn color="blue darken-1 align-center" outlined  @click="setSpot(firstArea, firstSpot)">他の動画を見る</v-btn>
-              </v-card-actions>
-            </div>
-          </v-card>
-        </v-hover>
-      </v-col>
-      <v-col cols="12" sm="12" md="4" lg="4">
-        <v-hover v-slot="{ hover }">
-          <v-card  :elevation="hover ? 12 : 2" max-width="400px" style="margin: auto;">
-            <v-img :src="secondVideo.thumbnail" alt="サムネイル"  @click="openDialog(secondArea, secondSpot, secondVideo);" style="cursor: pointer"></v-img>
-            <div class="d-flex justify-space-between">
-              <v-list-item>
-                <v-list-item-content>
-                  <v-list-item-subtitle class="mb-2">ランキング第2位</v-list-item-subtitle>
-                  <v-list-item-title>{{ secondSpot.name }}</v-list-item-title>
-                  <v-list-item-subtitle class="mt-1">{{ secondArea.name }}</v-list-item-subtitle>
-                </v-list-item-content>
-              </v-list-item>
-              <v-card-actions>
-                <v-btn color="blue darken-1" outlined  @click="setSpot(secondArea, secondSpot)">他の動画を見る</v-btn>
-              </v-card-actions>
-            </div>
-          </v-card>
-        </v-hover>
-      </v-col>
-      <v-col cols="12" sm="12" md="4" lg="4">
-        <v-hover v-slot="{ hover }">
-          <v-card  :elevation="hover ? 12 : 2" max-width="400px" style="margin: auto;">
-            <v-img :src="thirdVideo.thumbnail" alt="サムネイル"  @click="openDialog(thirdArea, thirdSpot, thirdVideo);" style="cursor: pointer"></v-img>
-            <div class="d-flex justify-space-between">
-              <v-list-item>
-                <v-list-item-content>
-                  <v-list-item-subtitle class="mb-2">ランキング第3位</v-list-item-subtitle>
-                  <v-list-item-title>{{ thirdSpot.name }}</v-list-item-title>
-                  <v-list-item-subtitle class="mt-1">{{ thirdArea.name }}</v-list-item-subtitle>
-                </v-list-item-content>
-              </v-list-item>
-              <v-card-actions>
-                <v-btn color="blue darken-1" outlined  @click="setSpot(thirdArea, thirdSpot)">他の動画を見る</v-btn>
+                <v-btn color="blue darken-1 align-center" text  @click="setSpot(spotDetail.area, spotDetail.spot)">行ってみる！</v-btn>
               </v-card-actions>
             </div>
           </v-card>
@@ -71,10 +41,18 @@
     <v-sheet class="mx-auto hidden-sm-and-down" max-width="1400">
       <v-slide-group class="px-4" active-class="success" show-arrows height="400">
         <v-slide-item
-          v-for="spotDetail in spotDetails" :key="spotDetail.id">
+          v-for="spotDetail in bigLimitCount" :key="spotDetail.id">
           <v-hover v-slot="{ hover }">
             <v-card  :elevation="hover ? 12 : 2" width="300" class="ma-2" style="margin: auto;">
               <v-img :src="spotDetail.video.thumbnail" alt="サムネイル"  @click="openDialog(spotDetail.area, spotDetail.spot, spotDetail.video);" style="cursor: pointer"></v-img>
+              <template v-if="authUser">
+                <v-btn v-if="spotDetail.heart == true" class="btn ma-2" fab small color="white" @click="unBookmark(spotDetail.id, spotDetail.spot.id)">
+                  <v-icon color="pink">mdi-heart</v-icon>
+                </v-btn>
+                <v-btn v-else class="btn ma-2" fab small color="white" @click="bookmark(spotDetail.id, spotDetail.spot.id)">
+                  <v-icon color="pink">mdi-heart-outline</v-icon>
+                </v-btn>
+              </template>
               <div class="d-flex justify-space-between">
                 <v-list-item>
                   <v-list-item-content>
@@ -151,22 +129,15 @@
 
 <script>
 import axios from '../plugins/axios'
+import { mapGetters } from "vuex"
 
 export default {
   data() {
     return {
-      // 地点ランキング上位三つの各オブジェクト
-      firstSpot: {},
-      secondSpot: {},
-      thirdSpot: {},
-      firstArea: {},
-      secondArea: {},
-      thirdArea: {},
-      firstVideo: {},
-      secondVideo: {},
-      thirdVideo: {},
       // すべての地点その国、動画オブジェクトを格納する配列
       spotDetails: [],
+      // 地点ランキング上位三つの各オブジェクトを格納する配列
+      spotBookmarks: [],
       // ダイアログに渡すdata
       dialog: false,
       title: '',
@@ -179,7 +150,15 @@ export default {
     }
   },
   created() {
-    this.getSpot();
+    // ログイン中の時のみ実行
+    if(this.authUser) {
+    // お気に入りに登録されている地点を取得
+      this.getBookmarks();
+      // すべての地点を取得し表示
+      this.getSpot();
+    } else {
+      this.getSpot();
+    }
   },
   // データの変更
   watch: {
@@ -190,23 +169,31 @@ export default {
       }
     },
   },
+  computed: {
+    // mapGettersでログイン中のユーザを取得
+    ...mapGetters("users", ["authUser"]),
+    // 画面幅（xl, sm）に合わせてホットスポットの表示制限
+    smallLimitCount() {
+      return this.spotDetails.slice(0,3);
+    },
+    // 画面幅（md, lg）に合わせてホットスポットの表示制限
+    bigLimitCount() {
+      return this.spotDetails.slice(0,8);
+    },
+  },
   methods: {
     // すべての地点とその国、動画を取得
     getSpot() {
       axios.get('/all_spot')
       .then( res => {
-        for(let i = 0; i < 12; i++) {
-          this.spotDetails.push( {id: i, spot: res.data.spots[i], area: res.data.areas[i], video: res.data.videos[i]} )
+        for(let i = 0; i < res.data.spots.length; i++) {
+          // 取得した地点の中にユーザがお気に入り登録している地点があるかを判別する
+          if (this.spotBookmarks.includes(res.data.spots[i].id)) {
+            this.spotDetails.push( {id: i, spot: res.data.spots[i], area: res.data.areas[i], video: res.data.videos[i], heart: true } );
+          } else {
+            this.spotDetails.push( {id: i, spot: res.data.spots[i], area: res.data.areas[i], video: res.data.videos[i], heart: false } );
+          }
         };
-        this.firstSpot = res.data.spots[0]
-        this.secondSpot = res.data.spots[1]
-        this.thirdSpot = res.data.spots[2]
-        this.firstArea = res.data.areas[0]
-        this.secondArea = res.data.areas[1]
-        this.thirdArea = res.data.areas[2]
-        this.firstVideo = res.data.videos[0]
-        this.secondVideo = res.data.videos[1]
-        this.thirdVideo = res.data.videos[2]
       })
     },
     // クリックしたカードの地点の国の詳細ページに遷移させる処理
@@ -227,6 +214,41 @@ export default {
       .catch(error => {
         console.log(error);
       })
+    },
+    // お気に入りに登録されている地点を取得
+    getBookmarks() {
+      axios.get('/bookmarks')
+      .then( res => {
+        for(let i = 0; i < res.data.spots.length; i++) {
+          this.spotBookmarks.push(res.data.spots[i].id);
+        };
+      })
+      .catch(error => {
+        console.log(error);
+      });
+    },
+    // お気に入りに登録する
+    bookmark(id, spot) {
+      this.spotDetails[id].heart = true;
+      axios.post('/bookmarks', { spot_id: spot })
+      // .then(res => {
+      //   console.log(res.data.status);
+      // })
+      .catch(error => {
+        console.log(error);
+      });
+    },
+    // お気に入り登録を解除する
+    unBookmark(id, spot) {
+      // お気に入りスポットの配列から削除（非同期処理）
+      this.spotDetails[id].heart = false;
+      axios.delete(`/bookmarks/${spot}`)
+      // .then(res => {
+      //   console.log(res.data.status);
+      // })
+      .catch(error => {
+        console.log(error);
+      });
     },
     // ダイアログの表示
     openDialog(area, spot, video) {
@@ -253,3 +275,15 @@ export default {
   }
 }
 </script>
+
+<style scoped>
+.v-responsive__content{
+  position: relative;
+}
+.btn{
+  position: absolute;
+  left: 0;
+  top: 0;
+  z-index: 2;
+}
+</style>

--- a/src/components/HomeSpotRanking.vue
+++ b/src/components/HomeSpotRanking.vue
@@ -1,22 +1,21 @@
 <template>
   <div>
-    <router-link to="/spotRanking" style="color: #455A64; text-decoration: none;">
-      <h2 class="d-flex align-center justify-center">
-        <v-icon left bottom color="red">mdi-fire</v-icon>
-        ホットスポット
-      </h2>
-    </router-link>
+    <h2 class="d-flex align-center justify-center">
+      <v-icon left bottom color="red">mdi-fire</v-icon>
+      ホットスポット
+    </h2>
     <v-divider class="mb-2 mx-auto" style="max-width: 1200px; width: 90%;"></v-divider>
 
     <!-- 画面幅がxs,smの時に表示 -->
-    <v-row class="mx-auto hidden-md-and-up">
+    <v-row class="mx-auto mb-2 hidden-md-and-up">
       <v-col cols="12" sm="12" md="4" lg="4">
         <v-hover v-slot="{ hover }">
-          <v-card  :elevation="hover ? 12 : 2" max-width="500px" style="margin: auto;">
+          <v-card  :elevation="hover ? 12 : 2" max-width="400px" style="margin: auto;">
             <v-img :src="firstVideo.thumbnail" alt="サムネイル"  @click="openDialog(firstArea, firstSpot, firstVideo);" style="cursor: pointer"></v-img>
             <div class="d-flex justify-space-between">
               <v-list-item>
                 <v-list-item-content>
+                  <v-list-item-subtitle class="mb-2">ランキング第1位</v-list-item-subtitle>
                   <v-list-item-title>{{ firstSpot.name }}</v-list-item-title>
                   <v-list-item-subtitle class="mt-1">{{ firstArea.name }}</v-list-item-subtitle>
                 </v-list-item-content>
@@ -30,11 +29,12 @@
       </v-col>
       <v-col cols="12" sm="12" md="4" lg="4">
         <v-hover v-slot="{ hover }">
-          <v-card  :elevation="hover ? 12 : 2" max-width="500px" style="margin: auto;">
+          <v-card  :elevation="hover ? 12 : 2" max-width="400px" style="margin: auto;">
             <v-img :src="secondVideo.thumbnail" alt="サムネイル"  @click="openDialog(secondArea, secondSpot, secondVideo);" style="cursor: pointer"></v-img>
             <div class="d-flex justify-space-between">
               <v-list-item>
                 <v-list-item-content>
+                  <v-list-item-subtitle class="mb-2">ランキング第2位</v-list-item-subtitle>
                   <v-list-item-title>{{ secondSpot.name }}</v-list-item-title>
                   <v-list-item-subtitle class="mt-1">{{ secondArea.name }}</v-list-item-subtitle>
                 </v-list-item-content>
@@ -46,13 +46,14 @@
           </v-card>
         </v-hover>
       </v-col>
-      <v-col cols="12" sm="12" md="4" lg="4" class="">
+      <v-col cols="12" sm="12" md="4" lg="4">
         <v-hover v-slot="{ hover }">
-          <v-card  :elevation="hover ? 12 : 2" max-width="500px" style="margin: auto;">
+          <v-card  :elevation="hover ? 12 : 2" max-width="400px" style="margin: auto;">
             <v-img :src="thirdVideo.thumbnail" alt="サムネイル"  @click="openDialog(thirdArea, thirdSpot, thirdVideo);" style="cursor: pointer"></v-img>
             <div class="d-flex justify-space-between">
               <v-list-item>
                 <v-list-item-content>
+                  <v-list-item-subtitle class="mb-2">ランキング第3位</v-list-item-subtitle>
                   <v-list-item-title>{{ thirdSpot.name }}</v-list-item-title>
                   <v-list-item-subtitle class="mt-1">{{ thirdArea.name }}</v-list-item-subtitle>
                 </v-list-item-content>
@@ -68,7 +69,7 @@
 
     <!-- 画面幅がmd, lg, xlで表示 -->
     <v-sheet class="mx-auto hidden-sm-and-down" max-width="1400">
-      <v-slide-group class="pa-4" active-class="success" show-arrows  height="400">
+      <v-slide-group class="px-4" active-class="success" show-arrows height="400">
         <v-slide-item
           v-for="spotDetail in spotDetails" :key="spotDetail.id">
           <v-hover v-slot="{ hover }">
@@ -77,6 +78,7 @@
               <div class="d-flex justify-space-between">
                 <v-list-item>
                   <v-list-item-content>
+                    <v-list-item-subtitle class="mb-2">ランキング第{{ spotDetail.id + 1 }}位</v-list-item-subtitle>
                     <v-list-item-title>{{ spotDetail.spot.name }}</v-list-item-title>
                     <v-list-item-subtitle class="mt-1">{{ spotDetail.area.name }}</v-list-item-subtitle>
                   </v-list-item-content>
@@ -90,6 +92,17 @@
         </v-slide-item>
       </v-slide-group>
     </v-sheet>
+
+    <v-col class="d-flex justify-center">
+      <v-btn
+        color="red"
+        outlined
+        to="/spotRanking"
+      >
+        <v-icon left>mdi-crown</v-icon>
+        ランキング一覧を見てみる
+      </v-btn>
+    </v-col>
 
     <!-- ダイアログボックス -->
     <v-dialog v-model="dialog" max-width="1200px">

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -8,24 +8,60 @@
       fixed
       temporary
     >
+
+      <v-list v-if="authUser">
+        <v-list-item
+          @click.native="triggerClick('profile')"
+          link
+        >
+          <v-list-item-avatar color="indigo">
+            <span class="white--text text-h5">{{ authUser.name.charAt(0) }}</span>
+          </v-list-item-avatar>
+          <v-list-item-content style="color: #455A64;">
+            <v-list-item-title>マイページ</v-list-item-title>
+          </v-list-item-content>
+        </v-list-item>
+      </v-list>
+
       <!-- 線 -->
       <v-divider></v-divider>
 
       <!-- メニュー表のリスト -->
       <v-list>
+        <v-list-item
+          v-for="item in items"
+          :key="item.title"
+          :to="item.url"
+          @click.native="triggerClick(item.action)"
+          link
+        >
+          <v-list-item-icon style="color: #455A64;">
+            <v-icon>{{ item.icon }}</v-icon>
+          </v-list-item-icon>
+
+          <v-list-item-content style="color: #455A64;">
+            <v-list-item-title>{{ item.title }}</v-list-item-title>
+          </v-list-item-content>
+        </v-list-item>
+      </v-list>
+
+      <!-- 線 -->
+      <v-divider></v-divider>
+
+      <v-list dense>
         <template v-if="!authUser">
           <v-list-item
-            v-for="item in items"
+            v-for="item in smallItems"
             :key="item.title"
             :to="item.url"
             @click.native="triggerClick(item.action)"
             link
           >
-            <v-list-item-icon>
+            <v-list-item-icon style="color: #455A64;">
               <v-icon>{{ item.icon }}</v-icon>
             </v-list-item-icon>
 
-            <v-list-item-content>
+            <v-list-item-content  style="color: #455A64;">
               <v-list-item-title>{{ item.title }}</v-list-item-title>
             </v-list-item-content>
           </v-list-item>
@@ -34,7 +70,7 @@
         <template v-else>
           <!-- リストを繰り返し処理で全て表示 -->
           <v-list-item
-            v-for="item in itemsLogin"
+            v-for="item in smallItemsLogin"
             :key="item.title"
             :to="item.url"
             @click.native="triggerClick(item.action)"
@@ -74,20 +110,15 @@ export default {
         { title: 'トップページ', icon: 'mdi-home-outline', url: '/' },
         { title: 'ホットスポット', icon: 'mdi-fire', url: '/spotRanking' },
         { title: 'お知らせ', icon: 'mdi-information-outline', url: '/newsList' },
-        // { title: 'スポットをリクエスト', icon: 'mdi-send-circle', url: '/spotRequest' },
+      ],
+      smallItems: [
         { title: 'ログイン', icon: 'mdi-login', url: '/login' },
-        { title: '新規登録', icon: 'mdi-account-plus', url: '/register' },
       ],
       // ログイン中のメニューリスト
-      itemsLogin: [
-        { title: 'トップページ', icon: 'mdi-home-outline', url: '/' },
-        { title: 'ホットスポット', icon: 'mdi-fire', url: '/spotRanking' },
-        { title: 'お知らせ', icon: 'mdi-information-outline', url: '/newsList' },
-        // { title: 'お気に入り地点', icon: 'mdi-heart-outline', url: '' },
+      smallItemsLogin: [
         { title: 'スポットをリクエスト', icon: 'mdi-send-circle', url: '/spotRequest' },
         { title: 'ログアウト', icon: 'mdi-logout', action: "logout" },
       ],
-      right: null,
     }
   },
   computed: {
@@ -101,7 +132,9 @@ export default {
     triggerClick(action) {
       if (action === 'logout') {
         this.logout()
-      }
+      } else if (action === 'profile') {
+        this.handleProfile()
+      };
     },
     // ログアウトを実行するメソッド
     async logout() {
@@ -113,6 +146,9 @@ export default {
       } catch (error) {
         console.log(error)
       }
+    },
+    handleProfile() {
+      this.$router.push({ name: "UserProfile", params: { id: this.authUser.id } });
     },
   }
 }

--- a/src/components/WorldMap.vue
+++ b/src/components/WorldMap.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <h2 class="mb-1 d-flex align-center justify-center">
-      <v-icon left bottom>mdi-map-outline</v-icon>
+      <v-icon left bottom color="blue darken-1">mdi-map-outline</v-icon>
       地図から探す
     </h2>
     <v-divider class="mb-2 mx-auto" style="max-width: 1200px; width: 90%;" ></v-divider>

--- a/src/pages/SpotRanking.vue
+++ b/src/pages/SpotRanking.vue
@@ -12,12 +12,19 @@
       <v-row class="mx-auto hidden-md-and-up">
         <v-col v-for="spotDetail in spotDetails" :key="spotDetail.id" cols="12" sm="6">
           <v-hover v-slot="{ hover }">
-            <v-card  :elevation="hover ? 12 : 2" max-width="400px" style="margin: auto;">
+            <v-card :elevation="hover ? 12 : 2" max-width="400px" style="margin: auto;">
               <v-img :src="spotDetail.video.thumbnail" alt="サムネイル"  @click="openDialog(spotDetail.area, spotDetail.spot, spotDetail.video);" style="cursor: pointer"></v-img>
+              <template v-if="authUser">
+                <v-btn v-if="spotDetail.heart == true" class="btn ma-2" fab small color="white" @click="unBookmark(spotDetail.id, spotDetail.spot.id)">
+                  <v-icon color="pink">mdi-heart</v-icon>
+                </v-btn>
+                <v-btn v-else class="btn ma-2" fab small color="white" @click="bookmark(spotDetail.id, spotDetail.spot.id)">
+                  <v-icon color="pink">mdi-heart-outline</v-icon>
+                </v-btn>
+              </template>
               <div class="d-flex justify-space-between">
                 <v-list-item>
                   <v-list-item-content>
-                    <!-- <v-list-item-subtitle small>過去{{ spotDetail.spot.click_count }}回の渡航歴</v-list-item-subtitle> -->
                     <v-list-item-subtitle small>ランキング第{{ spotDetail.id + 1 }}位</v-list-item-subtitle>
                     <v-list-item-title class="my-1">{{ spotDetail.spot.name }}</v-list-item-title>
                     <v-list-item-subtitle>{{ spotDetail.area.name }}</v-list-item-subtitle>
@@ -39,13 +46,29 @@
             <v-card :elevation="hover ? 12 : 2" max-width="500px" style="margin: auto;">
               <div class="d-flex justify-space-between">
                 <div class="d-flex flex-column">
+                  <template v-if="authUser">
+                    <v-btn v-if="spotDetail.heart == true" class="btn ma-2" fab small color="white" @click="unBookmark(spotDetail.id, spotDetail.spot.id)">
+                      <v-icon color="pink">mdi-heart</v-icon>
+                    </v-btn>
+                    <v-btn v-else class="btn ma-2" fab small color="white" @click="bookmark(spotDetail.id, spotDetail.spot.id)">
+                      <v-icon color="pink">mdi-heart-outline</v-icon>
+                  </v-btn>
+                  </template>
                   <v-list-item style="width: 160px;">
-                    <v-list-item-content>
-                      <!-- <v-list-item-subtitle class="mb-2">過去{{ spotDetail.spot.click_count }}回の渡航歴</v-list-item-subtitle> -->
-                      <v-list-item-subtitle class="mb-2">ランキング第{{ spotDetail.id + 1 }}位</v-list-item-subtitle>
-                      <v-list-item-title>{{ spotDetail.spot.name }}</v-list-item-title>
-                      <v-list-item-subtitle>{{ spotDetail.area.name }}</v-list-item-subtitle>
-                    </v-list-item-content>
+                    <template v-if="authUser">
+                      <v-list-item-content class="pt-12">
+                        <v-list-item-subtitle class="mb-2">ランキング第{{ spotDetail.id + 1 }}位</v-list-item-subtitle>
+                        <v-list-item-title>{{ spotDetail.spot.name }}</v-list-item-title>
+                        <v-list-item-subtitle>{{ spotDetail.area.name }}</v-list-item-subtitle>
+                      </v-list-item-content>
+                    </template>
+                    <template v-else>
+                      <v-list-item-content>
+                        <v-list-item-subtitle class="mb-2">ランキング第{{ spotDetail.id + 1 }}位</v-list-item-subtitle>
+                        <v-list-item-title>{{ spotDetail.spot.name }}</v-list-item-title>
+                        <v-list-item-subtitle>{{ spotDetail.area.name }}</v-list-item-subtitle>
+                      </v-list-item-content>
+                    </template>
                   </v-list-item>
                   <v-divider></v-divider>
                   <v-btn color="blue darken-1" text @click="setSpot(spotDetail.area, spotDetail.spot)">行ってみる！</v-btn>
@@ -106,12 +129,15 @@
 
 <script>
 import axios from '../plugins/axios'
+import { mapGetters } from "vuex"
 
 export default {
   data() {
     return {
       // すべての地点その国、動画オブジェクトを格納する配列
       spotDetails: [],
+      // ユーザがお気に入り登録している地点のidを格納する配列
+      spotBookmarks: [],
       // ダイアログに渡すdata
       dialog: false,
       title: '',
@@ -124,7 +150,15 @@ export default {
     }
   },
   created() {
-    this.getSpot();
+    // ログイン中の時のみ実行
+    if(this.authUser) {
+    // お気に入りに登録されている地点を取得
+      this.getBookmarks();
+      // すべての地点を取得し表示
+      this.getSpot();
+    } else {
+      this.getSpot();
+    }
   },
   // データの変更
   watch: {
@@ -135,20 +169,29 @@ export default {
       }
     },
   },
+  computed: {
+    // mapGettersでログイン中のユーザを取得
+    ...mapGetters("users", ["authUser"]),
+  },
   methods: {
     // すべての地点とその国、動画を取得
     getSpot() {
       axios.get('/all_spot')
       .then( res => {
         for(let i = 0; i < res.data.spots.length; i++) {
-          this.spotDetails.push( {id: i, spot: res.data.spots[i], area: res.data.areas[i], video: res.data.videos[i]} )
+          // 取得した地点の中にユーザがお気に入り登録している地点があるかを判別する
+          if (this.spotBookmarks.includes(res.data.spots[i].id)) {
+            this.spotDetails.push( {id: i, spot: res.data.spots[i], area: res.data.areas[i], video: res.data.videos[i], heart: true } );
+          } else {
+            this.spotDetails.push( {id: i, spot: res.data.spots[i], area: res.data.areas[i], video: res.data.videos[i], heart: false } );
+          }
         };
       })
     },
     // クリックしたカードの地点の国の詳細ページに遷移させる処理
     setSpot(area, spot) {
       // 地点のカウント数を+1する
-      this.clickCount(spot, area)
+      this.clickCount(spot, area);
       axios.get(`/countries/${spot.country_id}/spots`)
       .then( res => {
         this.$router.push({ name: "SpotResult", params: { id: res.data.area.id, spotId: spot.id} });
@@ -157,12 +200,47 @@ export default {
     // カードがクリックされた時に+1カウントされる
     clickCount(spot, area) {
       axios.get(`/countries/${area.id}/spots/${spot.id}/edit`)
-      .then(res => {
+      .then( res => {
         console.log(res.data.status);
       })
       .catch(error => {
         console.log(error);
       })
+    },
+    // お気に入りに登録されている地点を取得
+    getBookmarks() {
+      axios.get('/bookmarks')
+      .then( res => {
+        for(let i = 0; i < res.data.spots.length; i++) {
+          this.spotBookmarks.push(res.data.spots[i].id);
+        };
+      })
+      .catch(error => {
+        console.log(error);
+      });
+    },
+    // お気に入りに登録する
+    bookmark(id, spot) {
+      this.spotDetails[id].heart = true;
+      axios.post('/bookmarks', { spot_id: spot })
+      // .then(res => {
+      //   console.log(res.data.status);
+      // })
+      .catch(error => {
+        console.log(error);
+      });
+    },
+    // お気に入り登録を解除する
+    unBookmark(id, spot) {
+      // お気に入りスポットの配列から削除（非同期処理）
+      this.spotDetails[id].heart = false;
+      axios.delete(`/bookmarks/${spot}`)
+      // .then(res => {
+      //   console.log(res.data.status);
+      // })
+      .catch(error => {
+        console.log(error);
+      });
     },
     // ダイアログの表示
     openDialog(area, spot, video) {
@@ -191,5 +269,13 @@ export default {
 </script>
 
 <style scoped>
-
+.v-responsive__content{
+  position: relative;
+}
+.btn{
+  position: absolute;
+  left: 0;
+  top: 0;
+  z-index: 2;
+}
 </style>

--- a/src/pages/SpotRanking.vue
+++ b/src/pages/SpotRanking.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container class="my-16">
     <h2 class="mb-1 d-flex align-center justify-center">
-      <v-icon left bottom>mdi-fire</v-icon>
+      <v-icon left bottom color="red">mdi-fire</v-icon>
       ホットスポット
     </h2>
     <v-divider class="mb-2" style="max-width: 700px; margin: auto;"></v-divider>

--- a/src/pages/SpotRanking.vue
+++ b/src/pages/SpotRanking.vue
@@ -4,9 +4,36 @@
       <v-icon left bottom color="red">mdi-fire</v-icon>
       ホットスポット
     </h2>
+
     <v-divider class="mb-2" style="max-width: 700px; margin: auto;"></v-divider>
+
     <div class="d-flex justify-center">
-      <v-row style="max-width: 1000px; margin: auto;">
+      <!-- 画面幅がxs,smの時に表示 -->
+      <v-row class="mx-auto hidden-md-and-up">
+        <v-col v-for="spotDetail in spotDetails" :key="spotDetail.id" cols="12" sm="6">
+          <v-hover v-slot="{ hover }">
+            <v-card  :elevation="hover ? 12 : 2" max-width="400px" style="margin: auto;">
+              <v-img :src="spotDetail.video.thumbnail" alt="サムネイル"  @click="openDialog(spotDetail.area, spotDetail.spot, spotDetail.video);" style="cursor: pointer"></v-img>
+              <div class="d-flex justify-space-between">
+                <v-list-item>
+                  <v-list-item-content>
+                    <!-- <v-list-item-subtitle small>過去{{ spotDetail.spot.click_count }}回の渡航歴</v-list-item-subtitle> -->
+                    <v-list-item-subtitle small>ランキング第{{ spotDetail.id + 1 }}位</v-list-item-subtitle>
+                    <v-list-item-title class="my-1">{{ spotDetail.spot.name }}</v-list-item-title>
+                    <v-list-item-subtitle>{{ spotDetail.area.name }}</v-list-item-subtitle>
+                  </v-list-item-content>
+                </v-list-item>
+                <v-card-actions>
+                  <v-btn color="blue darken-1 align-center" text  @click="setSpot(spotDetail.area, spotDetail.spot)">行ってみる！</v-btn>
+                </v-card-actions>
+              </div>
+            </v-card>
+          </v-hover>
+        </v-col>
+      </v-row>
+
+      <!-- 画面幅がmd, lg, xlで表示 -->
+      <v-row class="hidden-sm-and-down" style="max-width: 1000px; margin: auto;">
         <v-col v-for="spotDetail in spotDetails" :key="spotDetail.id" cols="12" lg="6" md="12" sm="12">
           <v-hover v-slot="{ hover }">
             <v-card :elevation="hover ? 12 : 2" max-width="500px" style="margin: auto;">
@@ -14,23 +41,22 @@
                 <div class="d-flex flex-column">
                   <v-list-item style="width: 160px;">
                     <v-list-item-content>
-                      <v-list-item-subtitle class="mb-2">過去{{ spotDetail.spot.click_count }}回の渡航歴</v-list-item-subtitle>
+                      <!-- <v-list-item-subtitle class="mb-2">過去{{ spotDetail.spot.click_count }}回の渡航歴</v-list-item-subtitle> -->
+                      <v-list-item-subtitle class="mb-2">ランキング第{{ spotDetail.id + 1 }}位</v-list-item-subtitle>
                       <v-list-item-title>{{ spotDetail.spot.name }}</v-list-item-title>
                       <v-list-item-subtitle>{{ spotDetail.area.name }}</v-list-item-subtitle>
                     </v-list-item-content>
                   </v-list-item>
                   <v-divider></v-divider>
-                  <v-btn color="blue darken-1 align-center" class="hidden-sm-and-down" text @click="setSpot(spotDetail.area, spotDetail.spot)">行ってみる！</v-btn>
+                  <v-btn color="blue darken-1" text @click="setSpot(spotDetail.area, spotDetail.spot)">行ってみる！</v-btn>
                 </div>
-                <v-img :src="spotDetail.video.thumbnail" alt="サムネイル"  @click="openDialog(spotDetail.area, spotDetail.spot, spotDetail.video);" class="hidden-sm-and-down" style="cursor: pointer"></v-img>
-                <v-card-actions class="hidden-md-and-up">
-                  <v-btn color="blue darken-1 align-center" text @click="setSpot(spotDetail.area, spotDetail.spot)">行ってみる</v-btn>
-                </v-card-actions>
+                <v-img :src="spotDetail.video.thumbnail" alt="サムネイル"  @click="openDialog(spotDetail.area, spotDetail.spot, spotDetail.video);" style="cursor: pointer"></v-img>
               </div>
             </v-card>
           </v-hover>
         </v-col>
       </v-row>
+
     </div>
 
     <!-- ダイアログボックス -->

--- a/src/pages/SpotRequest.vue
+++ b/src/pages/SpotRequest.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container class="my-16">
     <h2 class="mb-1 d-flex align-center justify-center">
-      <v-icon left bottom>mdi-send-circle</v-icon>
+      <v-icon left bottom color="green darken-1">mdi-send-circle</v-icon>
       スポットをリクエスト
     </h2>
     <v-divider class="mb-4" style="max-width: 700px; margin: auto;"></v-divider>

--- a/src/pages/SpotResult.vue
+++ b/src/pages/SpotResult.vue
@@ -13,19 +13,30 @@
 
     <template v-if="videos.length != 0">
       <v-row style="max-width: 1200px; margin: auto;">
-        <v-col lg="6" class="d-flex align-end pb-0">
+        <v-col cols="12" sm="6" md="6" lg="6" class="d-lg-flex align-lg-end d-md-flex align-md-end d-sm-flex align-sm-end pb-0">
           <h4 class="mb-2 d-flex align-center justify-center">
-            <v-icon left bottom class="hidden-sm-and-down">mdi-map-marker</v-icon>
-            {{ spot_name }}
+            <v-icon left bottom>mdi-map-marker</v-icon>
+            {{ spotName }}
+            <!--  ログイン中のユーザーにのみお気に入りマークを表示 -->
+            <template v-if="authUser">
+              <v-icon v-if="heart" right bottom class="d-flex d-sm-none" color="pink" @click="unBookmark()">mdi-cards-heart</v-icon>
+              <v-icon v-else right bottom class="d-flex d-sm-none" color="pink" @click="bookmark()">mdi-cards-heart-outline</v-icon>
+            </template>
           </h4>
+          <!--  ログイン中のユーザーにのみお気に入りマークを表示 -->
+          <template v-if="authUser">
+            <v-icon v-if="heart" right bottom class="mb-2 d-none d-sm-flex" color="pink" @click="unBookmark()">mdi-cards-heart</v-icon>
+            <v-icon v-else right bottom class="mb-2 d-none d-sm-flex" color="pink" @click="bookmark()">mdi-cards-heart-outline</v-icon>
+          </template>
         </v-col>
-        <v-col lg="6 pb-0">
+        <v-col cols="12" sm="6" md="6" lg="6" class="pa-0">
           <v-tabs right v-model="currentTab">
             <v-tab @click="viewOrder(videos)" :value="'viewTab'">閲覧順</v-tab>
             <v-tab @click="newOrder(videos)">新着順</v-tab>
           </v-tabs>
         </v-col>
       </v-row>
+
       <v-divider style="max-width: 1200px; margin: auto;"></v-divider>
     </template>
     <template v-else>
@@ -40,6 +51,7 @@
 
 <script>
 import axios from '../plugins/axios'
+import { mapGetters } from "vuex"
 import GoogleMap from '../components/GoogleMap.vue'
 import Video from '../components/Video.vue'
 
@@ -54,7 +66,10 @@ export default {
       area: {},
       spots: [],
       spot: {},
-      spot_name: '',
+      // ブックマーク登録する際に使うspotデータ
+      markSpot: {},
+      heart: false,
+      spotName: '',
       videos: [],
       // タブのフォーカス
       currentTab: "viewTab",
@@ -67,7 +82,10 @@ export default {
     } else {
       this.setSpotAndVideo()
     }
-    // 立ち上がり時に国に関する地点を取得
+  },
+  computed: {
+    // mapGettersでログイン中のユーザを取得
+    ...mapGetters("users", ["authUser"]),
   },
   methods: {
     // 国に関する地点を取得
@@ -97,7 +115,10 @@ export default {
       })
       .then(res => {
         this.videos = res.data;
-        this.spot_name = spot.name
+        this.spotName = spot.name
+        // ===================
+        this.bookmarked(spot);
+        // ===================
       })
       .catch(error => {
         console.log(error)
@@ -120,6 +141,9 @@ export default {
         };
         // propsで引き継いだ地点の動画を取得
         this.getVideo(this.spot, this.area);
+        // ===================
+        this.bookmarked(this.spot);
+        // ===================
       })
       .catch(error => {
         console.log(error)
@@ -128,13 +152,74 @@ export default {
     },
     // マーカー(地点)がクリックされた時に+1カウントされる
     clickCount(spot, area) {
+      this.markSpot = spot;
       axios.get(`/countries/${area.id}/spots/${spot.id}/edit`)
       .then(res => {
         console.log(res.data.status);
       })
       .catch(error => {
         console.log(error);
+      });
+    },
+    // ブックマーク済みかを確認
+    bookmarked(spot) {
+      axios.get('/bookmarked', {
+        params: {
+          spot_id: spot.id
+        }
       })
+      .then(res => {
+        if(res.data.status == 'yes') {
+          this.heart = true;
+        } else {
+          this.heart = false;
+        }
+      })
+      .catch(error => {
+        console.log(error);
+      });
+    },
+    // ブックマークに登録する
+    bookmark() {
+      this.heart = true;
+      if(this.markSpot.id == undefined) {
+        axios.post('/bookmarks', { spot_id: this.spot.id })
+        .then(res => {
+          console.log(res.data.status);
+        })
+        .catch(error => {
+          console.log(error);
+        });
+      } else {
+        axios.post('/bookmarks', { spot_id: this.markSpot.id })
+        .then(res => {
+          console.log(res.data.status);
+        })
+        .catch(error => {
+          console.log(error);
+        });
+      }
+    },
+    // ブックマーク登録を解除する
+    unBookmark() {
+      this.heart = false;
+      if(this.markSpot.id == undefined) {
+        axios.delete(`/bookmarks/${this.spot.id}`)
+        .then(res => {
+          console.log(res.data.status);
+        })
+        .catch(error => {
+          console.log(error);
+        });
+      } else {
+        axios.delete(`/bookmarks/${this.markSpot.id}`)
+        .then(res => {
+          console.log(res.data.status);
+        })
+        .catch(error => {
+          console.log(error);
+        });
+      }
     },
     // 動画を新着順に並び替える
     newOrder(videos) {

--- a/src/pages/SpotResult.vue
+++ b/src/pages/SpotResult.vue
@@ -66,7 +66,7 @@ export default {
       area: {},
       spots: [],
       spot: {},
-      // ブックマーク登録する際に使うspotデータ
+      // お気に入り登録する際に使うspotデータ
       markSpot: {},
       heart: false,
       spotName: '',
@@ -116,9 +116,8 @@ export default {
       .then(res => {
         this.videos = res.data;
         this.spotName = spot.name
-        // ===================
+        // お気に入り登録されているかを確認
         this.bookmarked(spot);
-        // ===================
       })
       .catch(error => {
         console.log(error)
@@ -141,9 +140,8 @@ export default {
         };
         // propsで引き継いだ地点の動画を取得
         this.getVideo(this.spot, this.area);
-        // ===================
+        // お気に入り登録されているかを確認
         this.bookmarked(this.spot);
-        // ===================
       })
       .catch(error => {
         console.log(error)
@@ -154,14 +152,14 @@ export default {
     clickCount(spot, area) {
       this.markSpot = spot;
       axios.get(`/countries/${area.id}/spots/${spot.id}/edit`)
-      .then(res => {
-        console.log(res.data.status);
-      })
+      // .then(res => {
+      //   console.log(res.data.status);
+      // })
       .catch(error => {
         console.log(error);
       });
     },
-    // ブックマーク済みかを確認
+    // お気に入り済みかを確認
     bookmarked(spot) {
       axios.get('/bookmarked', {
         params: {
@@ -179,43 +177,43 @@ export default {
         console.log(error);
       });
     },
-    // ブックマークに登録する
+    // お気に入りに登録する
     bookmark() {
       this.heart = true;
       if(this.markSpot.id == undefined) {
         axios.post('/bookmarks', { spot_id: this.spot.id })
-        .then(res => {
-          console.log(res.data.status);
-        })
+        // .then(res => {
+        //   console.log(res.data.status);
+        // })
         .catch(error => {
           console.log(error);
         });
       } else {
         axios.post('/bookmarks', { spot_id: this.markSpot.id })
-        .then(res => {
-          console.log(res.data.status);
-        })
+        // .then(res => {
+        //   console.log(res.data.status);
+        // })
         .catch(error => {
           console.log(error);
         });
       }
     },
-    // ブックマーク登録を解除する
+    // お気に入り登録を解除する
     unBookmark() {
       this.heart = false;
       if(this.markSpot.id == undefined) {
         axios.delete(`/bookmarks/${this.spot.id}`)
-        .then(res => {
-          console.log(res.data.status);
-        })
+        // .then(res => {
+        //   console.log(res.data.status);
+        // })
         .catch(error => {
           console.log(error);
         });
       } else {
         axios.delete(`/bookmarks/${this.markSpot.id}`)
-        .then(res => {
-          console.log(res.data.status);
-        })
+        // .then(res => {
+        //   console.log(res.data.status);
+        // })
         .catch(error => {
           console.log(error);
         });

--- a/src/pages/SpotResult.vue
+++ b/src/pages/SpotResult.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container class="my-16">
     <h2 class="mb-1 d-flex align-center justify-center">
-      <v-icon left bottom>mdi-earth</v-icon>
+      <v-icon left bottom color="cyan darken-1">mdi-earth</v-icon>
       {{ area.name }}
     </h2>
     <v-divider class="mb-2" style="max-width: 700px; margin: auto;"></v-divider>
@@ -19,14 +19,14 @@
             {{ spotName }}
             <!--  ログイン中のユーザーにのみお気に入りマークを表示 -->
             <template v-if="authUser">
-              <v-icon v-if="heart" right bottom class="d-flex d-sm-none" color="pink" @click="unBookmark()">mdi-cards-heart</v-icon>
-              <v-icon v-else right bottom class="d-flex d-sm-none" color="pink" @click="bookmark()">mdi-cards-heart-outline</v-icon>
+              <v-icon v-if="heart" right bottom class="d-flex d-sm-none" color="pink" @click="unBookmark()">mdi-heart</v-icon>
+              <v-icon v-else right bottom class="d-flex d-sm-none" color="pink" @click="bookmark()">mdi-heart-outline</v-icon>
             </template>
           </h4>
           <!--  ログイン中のユーザーにのみお気に入りマークを表示 -->
           <template v-if="authUser">
-            <v-icon v-if="heart" right bottom class="mb-2 d-none d-sm-flex" color="pink" @click="unBookmark()">mdi-cards-heart</v-icon>
-            <v-icon v-else right bottom class="mb-2 d-none d-sm-flex" color="pink" @click="bookmark()">mdi-cards-heart-outline</v-icon>
+            <v-icon v-if="heart" right bottom class="mb-2 d-none d-sm-flex" color="pink" @click="unBookmark()">mdi-heart</v-icon>
+            <v-icon v-else right bottom class="mb-2 d-none d-sm-flex" color="pink" @click="bookmark()">mdi-heart-outline</v-icon>
           </template>
         </v-col>
         <v-col cols="12" sm="6" md="6" lg="6" class="pa-0">

--- a/src/pages/UserProfile.vue
+++ b/src/pages/UserProfile.vue
@@ -66,11 +66,11 @@
               <v-card :elevation="hover ? 12 : 2" max-width="500px" style="margin: auto;">
                 <div class="d-flex justify-space-between">
                   <div class="d-flex flex-column">
-                    <v-btn class="ma-2" fab small color="white" @click="unBookmark(spotDetail.id, spotDetail.spot.id)">
+                    <v-btn class="btn ma-2" fab small color="white" @click="unBookmark(spotDetail.id, spotDetail.spot.id)">
                       <v-icon color="pink">mdi-heart</v-icon>
                     </v-btn>
                     <v-list-item style="width: 160px;">
-                      <v-list-item-content>
+                      <v-list-item-content class="mt-3">
                         <v-list-item-title>{{ spotDetail.spot.name }}</v-list-item-title>
                         <v-list-item-subtitle>{{ spotDetail.area.name }}</v-list-item-subtitle>
                       </v-list-item-content>
@@ -162,7 +162,7 @@ export default {
     }
   },
   created() {
-    this.getBookmarks()
+    this.getBookmarks();
   },
   watch: {
     // ダイアログの状態を監視（表示、非表示の切り替えと同時にdataをリセット）
@@ -196,7 +196,7 @@ export default {
         console.log(error);
       })
     },
-    // ブックマークに登録されている地点を取得
+    // お気に入りに登録されている地点を取得
     getBookmarks() {
       axios.get('/bookmarks')
       .then(res => {
@@ -208,14 +208,14 @@ export default {
         console.log(error);
       });
     },
-    // ブックマーク登録を解除する
+    // お気に入り登録を解除する
     unBookmark(id, spot) {
       // お気に入りスポットの配列から削除（非同期処理）
       this.spotDetails = this.spotDetails.filter((item) => item.id !== id);
       axios.delete(`/bookmarks/${spot}`)
-      .then(res => {
-        console.log(res.data.status);
-      })
+      // .then(res => {
+      //   console.log(res.data.status);
+      // })
       .catch(error => {
         console.log(error);
       });
@@ -252,6 +252,8 @@ export default {
 }
 .btn{
   position: absolute;
+  left: 0;
+  top: 0;
+  z-index: 2;
 }
-
 </style>

--- a/src/pages/UserProfile.vue
+++ b/src/pages/UserProfile.vue
@@ -24,36 +24,76 @@
     </v-row>
 
     <h2 class="mb-3 d-flex align-center justify-center">
-      <v-icon left bottom color="pink">mdi-cards-heart</v-icon>
+      <v-icon left bottom color="pink">mdi-heart</v-icon>
       Favorite Spot
     </h2>
+
     <v-divider class="mb-2" style="max-width: 700px; margin: auto;"></v-divider>
-    <div class="d-flex justify-center">
-      <v-row style="max-width: 1000px; margin: auto;">
-        <v-col v-for="spotDetail in spotDetails" :key="spotDetail.id" cols="12" lg="6" md="12" sm="12">
-          <v-hover v-slot="{ hover }">
-            <v-card :elevation="hover ? 12 : 2" max-width="500px" style="margin: auto;">
-              <div class="d-flex justify-space-between">
-                <div class="d-flex flex-column">
-                  <v-list-item style="width: 160px;">
+
+    <!-- お気に入り登録されているスポットがある時に表示 -->
+    <template v-if="spotDetails.length != 0">
+      <div class="d-flex justify-center">
+        <!-- 画面幅がxs,smの時に表示 -->
+        <v-row class="mx-auto hidden-md-and-up">
+          <v-col v-for="spotDetail in spotDetails" :key="spotDetail.id" cols="12" sm="6">
+            <v-hover v-slot="{ hover }">
+              <v-card  :elevation="hover ? 12 : 2" max-width="400px" style="margin: auto;">
+                <v-img :src="spotDetail.video.thumbnail" alt="サムネイル"  @click="openDialog(spotDetail.area, spotDetail.spot, spotDetail.video);" style="cursor: pointer">
+                </v-img>
+                <v-btn class="btn ma-2" fab small color="white" @click="unBookmark(spotDetail.id, spotDetail.spot.id)">
+                  <v-icon color="pink">mdi-heart</v-icon>
+                </v-btn>
+                <div class="d-flex justify-space-between">
+                  <v-list-item>
                     <v-list-item-content>
-                      <v-list-item-title>{{ spotDetail.spot.name }}</v-list-item-title>
+                      <v-list-item-title class="my-1">{{ spotDetail.spot.name }}</v-list-item-title>
                       <v-list-item-subtitle>{{ spotDetail.area.name }}</v-list-item-subtitle>
                     </v-list-item-content>
                   </v-list-item>
-                  <v-divider></v-divider>
-                  <v-btn color="blue darken-1 align-center" class="hidden-sm-and-down" text @click="setSpot(spotDetail.area, spotDetail.spot)">行ってみる！</v-btn>
+                  <v-card-actions>
+                    <v-btn color="blue darken-1 align-center" text  @click="setSpot(spotDetail.area, spotDetail.spot)">行ってみる！</v-btn>
+                  </v-card-actions>
                 </div>
-                <v-img :src="spotDetail.video.thumbnail" alt="サムネイル"  @click="openDialog(spotDetail.area, spotDetail.spot, spotDetail.video);" class="hidden-sm-and-down" style="cursor: pointer"></v-img>
-                <v-card-actions class="hidden-md-and-up">
-                  <v-btn color="blue darken-1 align-center" text @click="setSpot(spotDetail.area, spotDetail.spot)">行ってみる</v-btn>
-                </v-card-actions>
-              </div>
-            </v-card>
-          </v-hover>
-        </v-col>
-      </v-row>
-    </div>
+              </v-card>
+            </v-hover>
+          </v-col>
+        </v-row>
+
+        <!-- 画面幅がmd, lg, xlで表示 -->
+        <v-row class="hidden-sm-and-down" style="max-width: 1000px; margin: auto;">
+          <v-col v-for="spotDetail in spotDetails" :key="spotDetail.id" cols="12" lg="6" md="12" sm="12">
+            <v-hover v-slot="{ hover }">
+              <v-card :elevation="hover ? 12 : 2" max-width="500px" style="margin: auto;">
+                <div class="d-flex justify-space-between">
+                  <div class="d-flex flex-column">
+                    <v-btn class="ma-2" fab small color="white" @click="unBookmark(spotDetail.id, spotDetail.spot.id)">
+                      <v-icon color="pink">mdi-heart</v-icon>
+                    </v-btn>
+                    <v-list-item style="width: 160px;">
+                      <v-list-item-content>
+                        <v-list-item-title>{{ spotDetail.spot.name }}</v-list-item-title>
+                        <v-list-item-subtitle>{{ spotDetail.area.name }}</v-list-item-subtitle>
+                      </v-list-item-content>
+                    </v-list-item>
+                    <v-divider></v-divider>
+                    <v-btn color="blue darken-1 align-center" text @click="setSpot(spotDetail.area, spotDetail.spot)">行ってみる！</v-btn>
+                  </div>
+                  <v-img :src="spotDetail.video.thumbnail" alt="サムネイル"  @click="openDialog(spotDetail.area, spotDetail.spot, spotDetail.video);" style="cursor: pointer"></v-img>
+                </div>
+              </v-card>
+            </v-hover>
+          </v-col>
+        </v-row>
+      </div>
+    </template>
+
+    <!-- お気に入り登録されているスポットがない時に表示 -->
+    <template v-else>
+      <v-chip label large class="mt-10 d-flex justify-center" color="pink" text-color="white" style="max-width: 700px; margin: auto;">
+        <v-icon left>mdi-heart-plus-outline</v-icon>
+        スポットをお気に入り登録してみよう！
+      </v-chip>
+    </template>
 
     <!-- ダイアログボックス -->
     <v-dialog v-model="dialog" max-width="1200px">
@@ -112,6 +152,7 @@ export default {
     return {
       // すべての地点その国、動画オブジェクトを格納する配列
       spotDetails: [],
+      heart: [],
       // ダイアログに渡すdata
       dialog: false,
       title: '',
@@ -139,18 +180,6 @@ export default {
     ...mapGetters("users", ["authUser"]),
   },
   methods: {
-    // ブックマークに登録されている地点を取得
-    getBookmarks() {
-      axios.get('/bookmarks')
-      .then(res => {
-        for(let i = 0; i < res.data.spots.length; i++) {
-          this.spotDetails.push( {id: i, spot: res.data.spots[i], area: res.data.areas[i], video: res.data.videos[i]} )
-        };
-      })
-      .catch(error => {
-        console.log(error);
-      });
-    },
     // クリックしたカードの地点の国の詳細ページに遷移させる処理
     setSpot(area, spot) {
       // 地点のカウント数を+1する
@@ -169,6 +198,30 @@ export default {
       .catch(error => {
         console.log(error);
       })
+    },
+    // ブックマークに登録されている地点を取得
+    getBookmarks() {
+      axios.get('/bookmarks')
+      .then(res => {
+        for(let i = 0; i < res.data.spots.length; i++) {
+          this.spotDetails.push( {id: i, spot: res.data.spots[i], area: res.data.areas[i], video: res.data.videos[i]} )
+        };
+      })
+      .catch(error => {
+        console.log(error);
+      });
+    },
+    // ブックマーク登録を解除する
+    unBookmark(id, spot) {
+      // お気に入りスポットの配列から削除（非同期処理）
+      this.spotDetails = this.spotDetails.filter((item) => item.id !== id);
+      axios.delete(`/bookmarks/${spot}`)
+      .then(res => {
+        console.log(res.data.status);
+      })
+      .catch(error => {
+        console.log(error);
+      });
     },
     // ダイアログの表示
     openDialog(area, spot, video) {
@@ -195,3 +248,13 @@ export default {
   },
 }
 </script>
+
+<style scoped>
+.v-responsive__content{
+  position: relative;
+}
+.btn{
+  position: absolute;
+}
+
+</style>

--- a/src/pages/UserProfile.vue
+++ b/src/pages/UserProfile.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container class="my-16">
     <h1 class="mb-3 d-flex align-center justify-center">
-      <v-icon left bottom>mdi-account-circle</v-icon>
+      <v-icon left bottom color="teal darken-1">mdi-account-circle</v-icon>
       マイページ
     </h1>
 
@@ -145,9 +145,6 @@ import axios from '../plugins/axios'
 import { mapGetters } from "vuex"
 
 export default {
-  props: {
-    id: String
-  },
   data() {
     return {
       // すべての地点その国、動画オブジェクトを格納する配列

--- a/src/pages/UserProfile.vue
+++ b/src/pages/UserProfile.vue
@@ -1,0 +1,197 @@
+<template>
+  <v-container class="my-16">
+    <h1 class="mb-3 d-flex align-center justify-center">
+      <v-icon left bottom>mdi-account-circle</v-icon>
+      マイページ
+    </h1>
+
+    <v-row class="mx-auto mb-10">
+      <v-col cols="12">
+        <v-card max-width="500px" class="mx-auto pa-5">
+          <v-list-item>
+            <v-list-item-avatar
+              color="indigo"
+              size="50"
+            >
+              <span class="white--text text-h5">{{ authUser.name.charAt(0) }}</span>
+            </v-list-item-avatar>
+            <v-list-item-content>
+              <v-list-item-title class="text-center">{{ authUser.name }}</v-list-item-title>
+            </v-list-item-content>
+          </v-list-item>
+        </v-card>
+      </v-col>
+    </v-row>
+
+    <h2 class="mb-3 d-flex align-center justify-center">
+      <v-icon left bottom color="pink">mdi-cards-heart</v-icon>
+      Favorite Spot
+    </h2>
+    <v-divider class="mb-2" style="max-width: 700px; margin: auto;"></v-divider>
+    <div class="d-flex justify-center">
+      <v-row style="max-width: 1000px; margin: auto;">
+        <v-col v-for="spotDetail in spotDetails" :key="spotDetail.id" cols="12" lg="6" md="12" sm="12">
+          <v-hover v-slot="{ hover }">
+            <v-card :elevation="hover ? 12 : 2" max-width="500px" style="margin: auto;">
+              <div class="d-flex justify-space-between">
+                <div class="d-flex flex-column">
+                  <v-list-item style="width: 160px;">
+                    <v-list-item-content>
+                      <v-list-item-title>{{ spotDetail.spot.name }}</v-list-item-title>
+                      <v-list-item-subtitle>{{ spotDetail.area.name }}</v-list-item-subtitle>
+                    </v-list-item-content>
+                  </v-list-item>
+                  <v-divider></v-divider>
+                  <v-btn color="blue darken-1 align-center" class="hidden-sm-and-down" text @click="setSpot(spotDetail.area, spotDetail.spot)">行ってみる！</v-btn>
+                </div>
+                <v-img :src="spotDetail.video.thumbnail" alt="サムネイル"  @click="openDialog(spotDetail.area, spotDetail.spot, spotDetail.video);" class="hidden-sm-and-down" style="cursor: pointer"></v-img>
+                <v-card-actions class="hidden-md-and-up">
+                  <v-btn color="blue darken-1 align-center" text @click="setSpot(spotDetail.area, spotDetail.spot)">行ってみる</v-btn>
+                </v-card-actions>
+              </div>
+            </v-card>
+          </v-hover>
+        </v-col>
+      </v-row>
+    </div>
+
+    <!-- ダイアログボックス -->
+    <v-dialog v-model="dialog" max-width="1200px">
+      <v-card>
+        <v-col>
+          <v-responsive :aspect-ratio="16/9">
+            <iframe
+              width="100%"
+              height="100%"
+              :src="urlForEmbedVideo"
+              frameborder="0"
+              autoplay
+              allowfullscreen
+              modestbranding="1"
+            ></iframe>
+          </v-responsive>
+        </v-col>
+        <v-card-subtitle class="py-0 font-weight-bold secondary--text">{{ title }}</v-card-subtitle>
+        <v-card-subtitle class="my-0 pb-1">{{ view_count.toLocaleString() }}回視聴・{{ published_at }}</v-card-subtitle>
+        <v-spacer></v-spacer>
+        <v-col class="d-flex justify-center pt-0">
+          <v-btn
+            color="blue darken-1"
+            outlined
+            @click="setSpot(area, spot)"
+          >
+            <v-icon left>mdi-video</v-icon>
+            {{ spot.name }}のVtour動画一覧
+          </v-btn>
+        </v-col>
+        <v-divider></v-divider>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn
+            color="blue darken-1"
+            text
+            @click="resetDialog()"
+          >
+            CLOSE
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </v-container>
+</template>
+
+<script>
+import axios from '../plugins/axios'
+import { mapGetters } from "vuex"
+
+export default {
+  props: {
+    id: String
+  },
+  data() {
+    return {
+      // すべての地点その国、動画オブジェクトを格納する配列
+      spotDetails: [],
+      // ダイアログに渡すdata
+      dialog: false,
+      title: '',
+      video_id: '',
+      view_count: '',
+      published_at: '',
+      urlForEmbedVideo: '',
+      area: {},
+      spot: {},
+    }
+  },
+  created() {
+    this.getBookmarks()
+  },
+  watch: {
+    // ダイアログの状態を監視（表示、非表示の切り替えと同時にdataをリセット）
+    dialog() {
+      if (!this.dialog) {
+        this.resetDialog()
+      }
+    },
+  },
+  computed: {
+    // mapGettersでログイン中のユーザを取得
+    ...mapGetters("users", ["authUser"]),
+  },
+  methods: {
+    // ブックマークに登録されている地点を取得
+    getBookmarks() {
+      axios.get('/bookmarks')
+      .then(res => {
+        for(let i = 0; i < res.data.spots.length; i++) {
+          this.spotDetails.push( {id: i, spot: res.data.spots[i], area: res.data.areas[i], video: res.data.videos[i]} )
+        };
+      })
+      .catch(error => {
+        console.log(error);
+      });
+    },
+    // クリックしたカードの地点の国の詳細ページに遷移させる処理
+    setSpot(area, spot) {
+      // 地点のカウント数を+1する
+      this.clickCount(spot, area)
+      axios.get(`/countries/${spot.country_id}/spots`)
+      .then( res => {
+        this.$router.push({ name: "SpotResult", params: { id: res.data.area.id, spotId: spot.id} });
+      })
+    },
+    // カードがクリックされた時に+1カウントされる
+    clickCount(spot, area) {
+      axios.get(`/countries/${area.id}/spots/${spot.id}/edit`)
+      .then(res => {
+        console.log(res.data.status);
+      })
+      .catch(error => {
+        console.log(error);
+      })
+    },
+    // ダイアログの表示
+    openDialog(area, spot, video) {
+      this.dialog = true;
+      this.title = video.title;
+      this.video_id = video.video_id;
+      this.view_count = video.view_count;
+      this.published_at = video.published_at;
+      this.urlForEmbedVideo = `https://www.youtube.com/embed/${this.video_id}`;
+      this.area =  area;
+      this.spot =  spot;
+    },
+    // ダイアログを非表示にしdataを空にする
+    resetDialog() {
+      this.dialog = false;
+      this.title = '';
+      this.video_id = '';
+      this.description = '';
+      this.view_count = '';
+      this.urlForEmbedVideo = '';
+      this.area =  [];
+      this.spot = [];
+    },
+  },
+}
+</script>

--- a/src/pages/auth/Register.vue
+++ b/src/pages/auth/Register.vue
@@ -116,9 +116,7 @@ export default {
     }
   },
   methods: {
-    ...mapActions("users", [
-      "registerUser"
-    ]),
+    ...mapActions("users", ["registerUser"]),
     // 新規登録を実行するメソッド
     register() {
       try {

--- a/src/router.js
+++ b/src/router.js
@@ -6,6 +6,7 @@ import SpotResult from "./pages/SpotResult.vue"
 import SpotRanking from "./pages/SpotRanking.vue"
 import SpotRequest from "./pages/SpotRequest.vue"
 import NewsList from "./pages/NewsList.vue"
+import UserProfile from "./pages/UserProfile.vue"
 import Login from "./pages/auth/Login.vue"
 import Register from "./pages/auth/Register.vue"
 
@@ -24,10 +25,13 @@ const router = new Router({
       path: "/countries/:id", component: SpotResult, name: "SpotResult", props: true,
     },
     {
-      path: "/login", component: Login, name: "Login"
+      path: "/profile/:id", component: UserProfile, name: "UserProfile", props: true, meta: { requiredAuth: true }
     },
     {
-      path: "/register", component: Register, name: "Register",
+      path: "/login", component: Login, name: "Login", meta: { loggedIn: true }
+    },
+    {
+      path: "/register", component: Register, name: "Register", meta: { loggedIn: true }
     },
     {
       path: "/spotRanking", component: SpotRanking, name: "SpotRanking",
@@ -46,9 +50,12 @@ router.beforeEach((to, from, next) => {
   // storeに認証済みのユーザが存在するかを問合せる
   store.dispatch("users/fetchAuthUser")
   .then(authUser => {
-    // 認証済みユーザーが存在しないかつ遷移先のページが要ログインのページであればログインページに飛ばすという処理
     if (to.matched.some(record => record.meta.requiredAuth) && !authUser) {
+      // 認証済みユーザーが存在しないかつ遷移先のページが要ログインのページであればログインページに飛ばすという処理
       next({ name: "Login" });
+    } else if (to.matched.some(record => record.meta.loggedIn) && authUser) {
+      // ログイン済みの時にログイン、新規登録ページにリダイレクトされないようにする処理
+      next({ name: "UserProfile", params: { id: authUser.id } });
     } else {
       next();
     }

--- a/src/router.js
+++ b/src/router.js
@@ -25,7 +25,7 @@ const router = new Router({
       path: "/countries/:id", component: SpotResult, name: "SpotResult", props: true,
     },
     {
-      path: "/profile/:id", component: UserProfile, name: "UserProfile", props: true, meta: { requiredAuth: true }
+      path: "/profile", component: UserProfile, name: "UserProfile", meta: { requiredAuth: true }
     },
     {
       path: "/login", component: Login, name: "Login", meta: { loggedIn: true }


### PR DESCRIPTION
## 実装内容

* 追加：動画一覧ページに地点のお気に入り登録、解除マークの実装 https://github.com/O-H-K-N/walk-tour-vue/pull/19/commits/6888d66d0140dabb9414a41ed0933af4761ff630 
* 追加：ユーザごとのマイページを実装 https://github.com/O-H-K-N/walk-tour-vue/pull/19/commits/bfa3934b7e0f1a377fd0e06e333eeffebfbf6997 
* 修正：マイページにお気に入り解除機能を実装 https://github.com/O-H-K-N/walk-tour-vue/pull/19/commits/b6de01b82195d6d41d7d73374e99f0d9fdff1f01 
* 追加：ランキングページでお気に入りの登録・解除ができる処理を実装 https://github.com/O-H-K-N/walk-tour-vue/pull/19/commits/a4da3b6b7e0ef5fa3542edd0fbc781e59eb02056 
* 追加：ホームのランキングページでお気に入りの登録・解除ができる処理を実装 https://github.com/O-H-K-N/walk-tour-vue/pull/19/commits/f20f086efc9c49212bc4642b3a323641e88273bd 

## できるようになること（ユーザ目線）

* 気に入った地点をお気に入り登録できる
* お気に入り登録した地点をお気に入り解除できる
* お気に入り登録した地点をマイページから確認できる
* お気に入り登録は、ホーム、ランキングページ、動画一覧ページからできる

## その他の実装内容

* 修正：ログイン後、ログイン・新規登録ページに遷移されないような処理を実装 https://github.com/O-H-K-N/walk-tour-vue/pull/19/commits/e516d852304be0609a7fce0978b1491bdf0b17d9 
* 修正：マイページのURLにuser_idが表示されないように修正 https://github.com/O-H-K-N/walk-tour-vue/pull/19/commits/a8475f7b90204dbd079781b234fa2969333cfa4b 
* 修正：ランキングの順位を明示 https://github.com/O-H-K-N/walk-tour-vue/pull/19/commits/c455fd74ce5c53888ebb643bc51976173ac3bf27 