### PR TITLE
英語に言語切り替えができる機能を実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dotenv": "^16.0.1",
     "jquery": "^3.6.0",
     "vue": "^2.6.14",
+    "vue-i18n": "8",
     "vue-router": "3",
     "vuetify": "^2.6.0",
     "vuex": "3"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@googlemaps/markerclusterer": "^2.0.8",
+    "@iconify/vue2": "^1.2.1",
     "axios": "^0.27.2",
     "core-js": "^3.8.3",
     "dotenv": "^16.0.1",

--- a/public/index.html
+++ b/public/index.html
@@ -15,7 +15,7 @@
       href="https://cdn.jsdelivr.net/npm/@mdi/font@latest/css/materialdesignicons.min.css"
     />
     <!-- OGP -->
-    <meta property="og:site_name" content="VtourHub" />
+    <meta property="og:site_name" content="VtourHub - 気になる街へ行こう" />
     <meta property="og:type" content="website" />
     <meta property="og:title" content="VtourHub - 気になる街へ行こう" />
     <meta property="og:url" content="https://vtourhub.jp/" />
@@ -25,7 +25,6 @@
     />
     <meta name="keywords" content="VtourHub、Virtual Tour、WalkingTour " />
     <meta property="og:image" content="https://vtourhub.jp/img/ogp_main.png" />
-    <meta property="og:site_name" content="VtourHub" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:image" content="https://vtourhub.jp/img/ogp_main.png" />
     <meta name="twitter:site" content="VtourHub" />
@@ -41,13 +40,13 @@
       // Your web app's Firebase configuration
       // For Firebase JS SDK v7.20.0 and later, measurementId is optional
       const firebaseConfig = {
-        apiKey: process.env.FIREBASE_API_KEY,
-        authDomain: 'vtourhub.firebaseapp.com',
-        projectId: 'vtourhub',
-        storageBucket: 'vtourhub.appspot.com',
-        messagingSenderId: '861507759655',
-        appId: '1:861507759655:web:28deb0c26462bc2996a802',
-        measurementId: 'G-QGCL8BL6FM',
+        apiKey: '<%= process.env.VUE_APP_FIREBASE_API_KEY %>',
+        authDomain: '<%= process.env.VUE_APP_FIREBASE_AUTH_DOMAIN %>',
+        projectId: '<%= process.env.VUE_APP_FIREBASE_PROJECT_ID %>',
+        storageBucket: '<%= process.env.VUE_APP_FIREBASE_STORAGE_BUCKET %>',
+        messagingSenderId: '<%= process.env.VUE_APP_FIREBASE_MESSAGING_SENDER_ID %>',
+        appId: '<%= process.env.VUE_APP_FIREBASE_APP_ID  %>',
+        measurementId: '<%= process.env.VUE_APP_FIREBASE_MEASUREMENT_ID %>',
       };
       // Initialize Firebase
       const app = initializeApp(firebaseConfig);

--- a/public/index.html
+++ b/public/index.html
@@ -41,7 +41,7 @@
       // Your web app's Firebase configuration
       // For Firebase JS SDK v7.20.0 and later, measurementId is optional
       const firebaseConfig = {
-        apiKey: 'AIzaSyBJ5TDo8-YiHIVK3EnoxmM5HqsZie_M9Io',
+        apiKey: process.env.FIREBASE_API_KEY,
         authDomain: 'vtourhub.firebaseapp.com',
         projectId: 'vtourhub',
         storageBucket: 'vtourhub.appspot.com',

--- a/src/components/AutoComplete.vue
+++ b/src/components/AutoComplete.vue
@@ -5,7 +5,7 @@
         v-model="value"
         :items="areaName"
         :label="$t('autocomplete.label')"
-        :no-data-text="$t('defaults.no-data')"
+        :no-data-text="$t('form.no_data')"
         solo
       >
       </v-autocomplete>
@@ -18,7 +18,7 @@
         v-model="valueEns"
         :items="areaNameEns"
         :label="$t('autocomplete.label')"
-        :no-data-text="$t('defaults.no-data')"
+        :no-data-text="$t('form.no_data')"
         solo
       >
       </v-autocomplete>
@@ -34,7 +34,6 @@ import axios from '../plugins/axios';
 import { mapActions } from 'vuex';
 
 export default {
-
   data() {
     return {
       areas: [],
@@ -55,8 +54,6 @@ export default {
         this.areas = res.data.areas;
         for (let i = 0; i < this.areas.length; i++) {
           this.areaName.push(this.areas[i].name);
-        }
-        for (let i = 0; i < this.areas.length; i++) {
           this.areaNameEns.push(this.areas[i].name_ens);
         }
       });

--- a/src/components/AutoComplete.vue
+++ b/src/components/AutoComplete.vue
@@ -1,56 +1,95 @@
 <template>
   <div class="d-flex justify-center" style="margin: auto" max-width="1000px">
-    <v-autocomplete
-      v-model="value"
-      :items="area_name"
-      label="国名から検索しよう"
-      no-data-text="データがありません"
-      solo
-    >
-    </v-autocomplete>
-    <v-btn class="ml-2 mt-1" bottom outlined small fab color="white" @click="getMap">
-      <v-icon>mdi-magnify</v-icon>
-    </v-btn>
+    <template v-if="this.$i18n.locale === 'ja'">
+      <v-autocomplete
+        v-model="value"
+        :items="areaName"
+        :label="$t('autocomplete.label')"
+        :no-data-text="$t('defaults.no-data')"
+        solo
+      >
+      </v-autocomplete>
+      <v-btn class="ml-2 mt-1" bottom outlined small fab color="white" @click="getMap">
+        <v-icon>mdi-magnify</v-icon>
+      </v-btn>
+    </template>
+    <template v-if="this.$i18n.locale === 'en'">
+      <v-autocomplete
+        v-model="valueEns"
+        :items="areaNameEns"
+        :label="$t('autocomplete.label')"
+        :no-data-text="$t('defaults.no-data')"
+        solo
+      >
+      </v-autocomplete>
+      <v-btn class="ml-2 mt-1" bottom outlined small fab color="white" @click="getMapEns">
+        <v-icon>mdi-magnify</v-icon>
+      </v-btn>
+    </template>
   </div>
 </template>
 
 <script>
 import axios from '../plugins/axios';
+import { mapActions } from 'vuex';
 
 export default {
+
   data() {
     return {
       areas: [],
-      area_name: [],
+      areaName: [],
+      areaNameEns: [],
       value: [],
+      valueEns: [],
     };
   },
-  created() {
+  mounted() {
     this.getArea();
   },
   methods: {
+    ...mapActions('util', ['openSnackbar', 'closeSnackbar']),
     // 地点を保有するエリア（国）を全て取得
     getArea() {
       axios.get('/countries').then((res) => {
         this.areas = res.data.areas;
         for (let i = 0; i < this.areas.length; i++) {
-          this.area_name.push(this.areas[i].name);
+          this.areaName.push(this.areas[i].name);
+        }
+        for (let i = 0; i < this.areas.length; i++) {
+          this.areaNameEns.push(this.areas[i].name_ens);
         }
       });
     },
+    // 日本語検索で国詳細ページへ遷移
     getMap() {
       if (this.value.length !== 0) {
         let i = 0;
         while (i < this.areas.length) {
-          if (this.value === this.areas[i].name) {
+          if (this.value === this.areas[i].name || this.value === this.areas[i].name_ens) {
             this.$router.push({ name: 'SpotResult', params: { id: this.areas[i].id } });
             break;
           }
           i++;
         }
-      } else {
-        alert('検索ワードを選択してください');
+        return;
       }
+      this.openSnackbar(this.$t('autocomplete.error_message'));
+    },
+    // 英語検索で国詳細ページへ遷移
+    getMapEns() {
+      if (this.valueEns.length !== 0) {
+        let i = 0;
+        while (i < this.areas.length) {
+          if (this.valueEns === this.areas[i].name_ens) {
+            this.$router.push({ name: 'SpotResult', params: { id: this.areas[i].id } });
+            break;
+          }
+          i++;
+        }
+        return;
+      }
+      this.openSnackbar(this.$t('autocomplete.error_message'));
     },
   },
 };

--- a/src/components/BackGroundVideo.vue
+++ b/src/components/BackGroundVideo.vue
@@ -17,10 +17,10 @@
       <!--   動画の上に載せるテキスト   -->
       <div class="mv-txt">
         <p class="mb-0">VtourHub</p>
-        <p style="font-size: xx-large">気になる街へ行こう</p>
+        <p style="font-size: xx-large">{{ $t('top.subtitle') }}</p>
         <AutoComplete :areas="areas" />
         <p class="font-weight-black text-decoration-underline" style="font-size: x-large">
-          {{ areas.length }}カ国 {{ spots.length }}地点を登録中
+          {{ $t('top.count', { areas: areas.length, spots: spots.length }) }}
         </p>
       </div>
     </div>

--- a/src/components/BaseMenu.vue
+++ b/src/components/BaseMenu.vue
@@ -8,7 +8,7 @@
             <span class="white--text text-h5">{{ authUser.name.charAt(0) }}</span>
           </v-list-item-avatar>
           <v-list-item-content style="color: #455a64">
-            <v-list-item-title>マイページ</v-list-item-title>
+            <v-list-item-title>{{ $t('menu.my_page') }}</v-list-item-title>
           </v-list-item-content>
         </v-list-item>
       </v-list>
@@ -18,19 +18,31 @@
 
       <!-- メニュー表のリスト -->
       <v-list>
-        <v-list-item
-          v-for="item in items"
-          :key="item.title"
-          :to="item.url"
-          @click.native="triggerClick(item.action)"
-          link
-        >
+        <v-list-item to="/" link>
           <v-list-item-icon style="color: #455a64">
-            <v-icon>{{ item.icon }}</v-icon>
+            <v-icon>mdi-home-outline</v-icon>
           </v-list-item-icon>
 
           <v-list-item-content style="color: #455a64">
-            <v-list-item-title>{{ item.title }}</v-list-item-title>
+            <v-list-item-title>{{ $t('menu.home') }}</v-list-item-title>
+          </v-list-item-content>
+        </v-list-item>
+        <v-list-item to="/spotRanking" link>
+          <v-list-item-icon style="color: #455a64">
+            <v-icon>mdi-fire</v-icon>
+          </v-list-item-icon>
+
+          <v-list-item-content style="color: #455a64">
+            <v-list-item-title>{{ $t('menu.hot_spot') }}</v-list-item-title>
+          </v-list-item-content>
+        </v-list-item>
+        <v-list-item to="/newsList" link>
+          <v-list-item-icon style="color: #455a64">
+            <v-icon>mdi-information-outline</v-icon>
+          </v-list-item-icon>
+
+          <v-list-item-content style="color: #455a64">
+            <v-list-item-title>{{ $t('menu.news') }}</v-list-item-title>
           </v-list-item-content>
         </v-list-item>
       </v-list>
@@ -40,40 +52,39 @@
 
       <v-list dense>
         <template v-if="!authUser">
-          <v-list-item
-            v-for="item in smallItems"
-            :key="item.title"
-            :to="item.url"
-            @click.native="triggerClick(item.action)"
-            link
-          >
+          <v-list-item to="/login" link>
             <v-list-item-icon style="color: #455a64">
-              <v-icon>{{ item.icon }}</v-icon>
+              <v-icon>mdi-login</v-icon>
             </v-list-item-icon>
 
             <v-list-item-content style="color: #455a64">
-              <v-list-item-title>{{ item.title }}</v-list-item-title>
+              <v-list-item-title>{{ $t('menu.login') }}</v-list-item-title>
             </v-list-item-content>
           </v-list-item>
         </template>
 
         <template v-else>
           <!-- リストを繰り返し処理で全て表示 -->
-          <v-list-item
-            v-for="item in smallItemsLogin"
-            :key="item.title"
-            :to="item.url"
-            @click.native="triggerClick(item.action)"
-            link
-          >
+          <v-list-item to="/spotRequest" link>
             <!-- リストのアイコン -->
             <v-list-item-icon style="color: #455a64">
-              <v-icon>{{ item.icon }}</v-icon>
+              <v-icon>mdi-send-circle</v-icon>
             </v-list-item-icon>
 
             <!-- リストのタイトル -->
             <v-list-item-content style="color: #455a64">
-              <v-list-item-title>{{ item.title }}</v-list-item-title>
+              <v-list-item-title>{{ $t('menu.request_spot') }}</v-list-item-title>
+            </v-list-item-content>
+          </v-list-item>
+          <v-list-item @click.native="triggerClick('logout')" link>
+            <!-- リストのアイコン -->
+            <v-list-item-icon style="color: #455a64">
+              <v-icon>mdi-logout</v-icon>
+            </v-list-item-icon>
+
+            <!-- リストのタイトル -->
+            <v-list-item-content style="color: #455a64">
+              <v-list-item-title>{{ $t('menu.logout') }}</v-list-item-title>
             </v-list-item-content>
           </v-list-item>
         </template>
@@ -92,22 +103,6 @@ export default {
       type: Boolean,
       default: false,
     },
-  },
-  data() {
-    return {
-      // 未ログインのメニューリスト
-      items: [
-        { title: 'トップページ', icon: 'mdi-home-outline', url: '/' },
-        { title: 'ホットスポット', icon: 'mdi-fire', url: '/spotRanking' },
-        { title: 'お知らせ', icon: 'mdi-information-outline', url: '/newsList' },
-      ],
-      smallItems: [{ title: 'ログイン', icon: 'mdi-login', url: '/login' }],
-      // ログイン中のメニューリスト
-      smallItemsLogin: [
-        { title: 'スポットをリクエスト', icon: 'mdi-send-circle', url: '/spotRequest' },
-        { title: 'ログアウト', icon: 'mdi-logout', action: 'logout' },
-      ],
-    };
   },
   computed: {
     // mapGettersでログイン中のユーザを取得

--- a/src/components/BaseMenu.vue
+++ b/src/components/BaseMenu.vue
@@ -8,7 +8,7 @@
             <span class="white--text text-h5">{{ authUser.name.charAt(0) }}</span>
           </v-list-item-avatar>
           <v-list-item-content style="color: #455a64">
-            <v-list-item-title>{{ $t('menu.my_page') }}</v-list-item-title>
+            <v-list-item-title>{{ $t('defaults.my_page') }}</v-list-item-title>
           </v-list-item-content>
         </v-list-item>
       </v-list>
@@ -33,7 +33,7 @@
           </v-list-item-icon>
 
           <v-list-item-content style="color: #455a64">
-            <v-list-item-title>{{ $t('menu.hot_spot') }}</v-list-item-title>
+            <v-list-item-title>{{ $t('defaults.hot_spot') }}</v-list-item-title>
           </v-list-item-content>
         </v-list-item>
         <v-list-item to="/newsList" link>

--- a/src/components/BaseMenu.vue
+++ b/src/components/BaseMenu.vue
@@ -127,7 +127,7 @@ export default {
         // ログアウト後、ログインページに遷移させる
         this.$router.push({ name: 'Login' });
         // フラッシュメッセージの表示処理の呼び出し
-        this.openSnackbar('ログアウトしました');
+        this.openSnackbar(this.$t('form.logout_success'));
       } catch (error) {
         console.log(error);
       }

--- a/src/components/BaseMenu.vue
+++ b/src/components/BaseMenu.vue
@@ -42,7 +42,7 @@
           </v-list-item-icon>
 
           <v-list-item-content style="color: #455a64">
-            <v-list-item-title>{{ $t('menu.news') }}</v-list-item-title>
+            <v-list-item-title>{{ $t('defaults.news') }}</v-list-item-title>
           </v-list-item-content>
         </v-list-item>
       </v-list>
@@ -73,7 +73,7 @@
 
             <!-- リストのタイトル -->
             <v-list-item-content style="color: #455a64">
-              <v-list-item-title>{{ $t('menu.request_spot') }}</v-list-item-title>
+              <v-list-item-title>{{ $t('defaults.request_spot') }}</v-list-item-title>
             </v-list-item-content>
           </v-list-item>
           <v-list-item @click.native="triggerClick('logout')" link>

--- a/src/components/BaseVideo.vue
+++ b/src/components/BaseVideo.vue
@@ -21,11 +21,14 @@
             <v-list-item>
               <v-list-item-content>
                 <v-list-item-title>{{ video.title }}</v-list-item-title>
-                <v-list-item-subtitle class="mt-1"
-                  >{{ video.view_count.toLocaleString() }}回視聴・{{
-                    video.published_at
-                  }}</v-list-item-subtitle
-                >
+                <v-list-item-subtitle class="mt-1">
+                  {{
+                    $t('defaults.video_detail', {
+                      count: video.view_count.toLocaleString(),
+                      published_at: video.published_at,
+                    })
+                  }}
+                </v-list-item-subtitle>
               </v-list-item-content>
             </v-list-item>
           </v-card>

--- a/src/components/BaseVideo.vue
+++ b/src/components/BaseVideo.vue
@@ -71,6 +71,10 @@ export default {
       type: String,
       required: true,
     },
+    spotEns: {
+      type: String,
+      required: true,
+    },
   },
   data() {
     return {
@@ -116,7 +120,7 @@ export default {
     shareTwitter(title, videoId) {
       var shareURL =
         'https://twitter.com/intent/tweet?text=' +
-        `${this.spot}（${this.area}）に行ってみたよ！` +
+        this.$t('share.content', { area: this.area, spot: this.spot, spot_ens: this.spotEns }) +
         '%0a' +
         '%0a' +
         encodeURI(title) +

--- a/src/components/HomeSpotRanking.vue
+++ b/src/components/HomeSpotRanking.vue
@@ -2,7 +2,7 @@
   <div>
     <h2 class="d-flex align-center justify-center">
       <v-icon left bottom color="red">mdi-fire</v-icon>
-      ホットスポット
+      {{ $t('top.hot_spot') }}
     </h2>
     <v-divider class="mb-2 mx-auto" style="max-width: 1200px; width: 90%" />
 
@@ -42,11 +42,21 @@
             <div class="d-flex justify-space-between">
               <v-list-item>
                 <v-list-item-content>
-                  <v-list-item-subtitle small
-                    >ランキング第{{ spotDetail.id + 1 }}位</v-list-item-subtitle
-                  >
-                  <v-list-item-title class="my-1">{{ spotDetail.spot.name }}</v-list-item-title>
-                  <v-list-item-subtitle>{{ spotDetail.area.name }}</v-list-item-subtitle>
+                  <v-list-item-subtitle class="mb-2">
+                    {{ $t('top.spot_order', { number: spotDetail.id + 1 }) }}
+                  </v-list-item-subtitle>
+                  <template v-if="$i18n.locale === 'ja'">
+                    <v-list-item-title>{{ spotDetail.spot.name }}</v-list-item-title>
+                    <v-list-item-subtitle class="mt-1">{{
+                      spotDetail.area.name
+                    }}</v-list-item-subtitle>
+                  </template>
+                  <template v-if="$i18n.locale === 'en'">
+                    <v-list-item-title>{{ spotDetail.spot.name_ens }}</v-list-item-title>
+                    <v-list-item-subtitle class="mt-1">{{
+                      spotDetail.area.name_ens
+                    }}</v-list-item-subtitle>
+                  </template>
                 </v-list-item-content>
               </v-list-item>
               <v-card-actions>
@@ -54,7 +64,7 @@
                   color="blue darken-1 align-center"
                   text
                   @click="setSpot(spotDetail.area, spotDetail.spot)"
-                  >行ってみる！</v-btn
+                  >{{ $t('top.spot_detail') }}</v-btn
                 >
               </v-card-actions>
             </div>
@@ -93,13 +103,21 @@
               <div class="d-flex justify-space-between">
                 <v-list-item>
                   <v-list-item-content>
-                    <v-list-item-subtitle class="mb-2"
-                      >ランキング第{{ spotDetail.id + 1 }}位</v-list-item-subtitle
-                    >
-                    <v-list-item-title>{{ spotDetail.spot.name }}</v-list-item-title>
-                    <v-list-item-subtitle class="mt-1">{{
-                      spotDetail.area.name
-                    }}</v-list-item-subtitle>
+                    <v-list-item-subtitle class="mb-2">
+                      {{ $t('top.spot_order', { number: spotDetail.id + 1 }) }}
+                    </v-list-item-subtitle>
+                    <template v-if="$i18n.locale === 'ja'">
+                      <v-list-item-title>{{ spotDetail.spot.name }}</v-list-item-title>
+                      <v-list-item-subtitle class="mt-1">{{
+                        spotDetail.area.name
+                      }}</v-list-item-subtitle>
+                    </template>
+                    <template v-if="$i18n.locale === 'en'">
+                      <v-list-item-title>{{ spotDetail.spot.name_ens }}</v-list-item-title>
+                      <v-list-item-subtitle class="mt-1">{{
+                        spotDetail.area.name_ens
+                      }}</v-list-item-subtitle>
+                    </template>
                   </v-list-item-content>
                 </v-list-item>
                 <v-card-actions>
@@ -107,7 +125,7 @@
                     color="blue darken-1 align-center"
                     text
                     @click="setSpot(spotDetail.area, spotDetail.spot)"
-                    >行ってみる！</v-btn
+                    >{{ $t('top.spot_detail') }}</v-btn
                   >
                 </v-card-actions>
               </div>
@@ -147,13 +165,21 @@
               <div class="d-flex justify-space-between">
                 <v-list-item>
                   <v-list-item-content>
-                    <v-list-item-subtitle class="mb-2"
-                      >ランキング第{{ spotDetail.id + 1 }}位</v-list-item-subtitle
-                    >
-                    <v-list-item-title>{{ spotDetail.spot.name }}</v-list-item-title>
-                    <v-list-item-subtitle class="mt-1">{{
-                      spotDetail.area.name
-                    }}</v-list-item-subtitle>
+                    <v-list-item-subtitle class="mb-2">
+                      {{ $t('top.spot_order', { number: spotDetail.id + 1 }) }}
+                    </v-list-item-subtitle>
+                    <template v-if="$i18n.locale === 'ja'">
+                      <v-list-item-title>{{ spotDetail.spot.name }}</v-list-item-title>
+                      <v-list-item-subtitle class="mt-1">{{
+                        spotDetail.area.name
+                      }}</v-list-item-subtitle>
+                    </template>
+                    <template v-if="$i18n.locale === 'en'">
+                      <v-list-item-title>{{ spotDetail.spot.name_ens }}</v-list-item-title>
+                      <v-list-item-subtitle class="mt-1">{{
+                        spotDetail.area.name_ens
+                      }}</v-list-item-subtitle>
+                    </template>
                   </v-list-item-content>
                 </v-list-item>
                 <v-card-actions>
@@ -161,7 +187,7 @@
                     color="blue darken-1 align-center"
                     text
                     @click="setSpot(spotDetail.area, spotDetail.spot)"
-                    >行ってみる！</v-btn
+                    >{{ $t('top.spot_detail') }}</v-btn
                   >
                 </v-card-actions>
               </div>
@@ -173,8 +199,8 @@
 
     <v-col class="d-flex justify-center">
       <v-btn color="red" outlined to="/spotRanking">
-        <v-icon left>mdi-crown</v-icon>
-        ランキング一覧を見てみる
+        <v-icon left class="b-1">mdi-crown</v-icon>
+        {{ $t('top.ranking_button') }}
       </v-btn>
     </v-col>
 

--- a/src/components/HomeSpotRanking.vue
+++ b/src/components/HomeSpotRanking.vue
@@ -2,7 +2,7 @@
   <div>
     <h2 class="d-flex align-center justify-center">
       <v-icon left bottom color="red">mdi-fire</v-icon>
-      {{ $t('top.hot_spot') }}
+      {{ $t('defaults.hot_spot') }}
     </h2>
     <v-divider class="mb-2 mx-auto" style="max-width: 1200px; width: 90%" />
 
@@ -43,7 +43,7 @@
               <v-list-item>
                 <v-list-item-content>
                   <v-list-item-subtitle class="mb-2">
-                    {{ $t('top.spot_order', { number: spotDetail.id + 1 }) }}
+                    {{ $t('defaults.spot_order', { number: spotDetail.id + 1 }) }}
                   </v-list-item-subtitle>
                   <template v-if="$i18n.locale === 'ja'">
                     <v-list-item-title>{{ spotDetail.spot.name }}</v-list-item-title>
@@ -64,7 +64,7 @@
                   color="blue darken-1 align-center"
                   text
                   @click="setSpot(spotDetail.area, spotDetail.spot)"
-                  >{{ $t('top.spot_detail') }}</v-btn
+                  >{{ $t('defaults.spot_detail') }}</v-btn
                 >
               </v-card-actions>
             </div>
@@ -104,7 +104,7 @@
                 <v-list-item>
                   <v-list-item-content>
                     <v-list-item-subtitle class="mb-2">
-                      {{ $t('top.spot_order', { number: spotDetail.id + 1 }) }}
+                      {{ $t('defaults.spot_order', { number: spotDetail.id + 1 }) }}
                     </v-list-item-subtitle>
                     <template v-if="$i18n.locale === 'ja'">
                       <v-list-item-title>{{ spotDetail.spot.name }}</v-list-item-title>
@@ -125,7 +125,7 @@
                     color="blue darken-1 align-center"
                     text
                     @click="setSpot(spotDetail.area, spotDetail.spot)"
-                    >{{ $t('top.spot_detail') }}</v-btn
+                    >{{ $t('defaults.spot_detail') }}</v-btn
                   >
                 </v-card-actions>
               </div>
@@ -166,7 +166,7 @@
                 <v-list-item>
                   <v-list-item-content>
                     <v-list-item-subtitle class="mb-2">
-                      {{ $t('top.spot_order', { number: spotDetail.id + 1 }) }}
+                      {{ $t('defaults.spot_order', { number: spotDetail.id + 1 }) }}
                     </v-list-item-subtitle>
                     <template v-if="$i18n.locale === 'ja'">
                       <v-list-item-title>{{ spotDetail.spot.name }}</v-list-item-title>
@@ -187,7 +187,7 @@
                     color="blue darken-1 align-center"
                     text
                     @click="setSpot(spotDetail.area, spotDetail.spot)"
-                    >{{ $t('top.spot_detail') }}</v-btn
+                    >{{ $t('defaults.spot_detail') }}</v-btn
                   >
                 </v-card-actions>
               </div>

--- a/src/components/NewAddSpot.vue
+++ b/src/components/NewAddSpot.vue
@@ -53,7 +53,7 @@
                   color="blue darken-1 align-center"
                   text
                   @click="setSpot(spotDetail.area, spotDetail.spot)"
-                  >{{ $t('top.spot_detail') }}</v-btn
+                  >{{ $t('defaults.spot_detail') }}</v-btn
                 >
               </v-card-actions>
             </div>
@@ -111,7 +111,7 @@
                     color="blue darken-1 align-center"
                     text
                     @click="setSpot(spotDetail.area, spotDetail.spot)"
-                    >{{ $t('top.spot_detail') }}</v-btn
+                    >{{ $t('defaults.spot_detail') }}</v-btn
                   >
                 </v-card-actions>
               </div>
@@ -170,7 +170,7 @@
                     color="blue darken-1 align-center"
                     text
                     @click="setSpot(spotDetail.area, spotDetail.spot)"
-                    >{{ $t('top.spot_detail') }}</v-btn
+                    >{{ $t('defaults.spot_detail') }}</v-btn
                   >
                 </v-card-actions>
               </div>

--- a/src/components/NewAddSpot.vue
+++ b/src/components/NewAddSpot.vue
@@ -1,8 +1,8 @@
 <template>
   <div v-if="spotDetails.length != 0">
-    <h2 class="d-flex align-center justify-center" v-bind="attrs" v-on="on">
+    <h2 class="d-flex align-center justify-center">
       <v-icon left bottom color="yellow darken-1">mdi-new-box</v-icon>
-      Newスポット
+      {{ $t('top.new_spot') }}
     </h2>
     <v-divider class="mb-2 mx-auto" style="max-width: 1200px; width: 90%" />
     <!-- 画面幅がxs,smの時に表示 -->
@@ -34,8 +34,18 @@
             <div class="d-flex justify-space-between">
               <v-list-item>
                 <v-list-item-content>
-                  <v-list-item-title class="my-1">{{ spotDetail.spot.name }}</v-list-item-title>
-                  <v-list-item-subtitle>{{ spotDetail.area.name }}</v-list-item-subtitle>
+                  <template v-if="$i18n.locale === 'ja'">
+                    <v-list-item-title>{{ spotDetail.spot.name }}</v-list-item-title>
+                    <v-list-item-subtitle class="mt-1">{{
+                      spotDetail.area.name
+                    }}</v-list-item-subtitle>
+                  </template>
+                  <template v-if="$i18n.locale === 'en'">
+                    <v-list-item-title>{{ spotDetail.spot.name_ens }}</v-list-item-title>
+                    <v-list-item-subtitle class="mt-1">{{
+                      spotDetail.area.name_ens
+                    }}</v-list-item-subtitle>
+                  </template>
                 </v-list-item-content>
               </v-list-item>
               <v-card-actions>
@@ -43,7 +53,7 @@
                   color="blue darken-1 align-center"
                   text
                   @click="setSpot(spotDetail.area, spotDetail.spot)"
-                  >行ってみる！</v-btn
+                  >{{ $t('top.spot_detail') }}</v-btn
                 >
               </v-card-actions>
             </div>
@@ -82,10 +92,18 @@
               <div class="d-flex justify-space-between">
                 <v-list-item>
                   <v-list-item-content>
-                    <v-list-item-title>{{ spotDetail.spot.name }}</v-list-item-title>
-                    <v-list-item-subtitle class="mt-1">{{
-                      spotDetail.area.name
-                    }}</v-list-item-subtitle>
+                    <template v-if="$i18n.locale === 'ja'">
+                      <v-list-item-title>{{ spotDetail.spot.name }}</v-list-item-title>
+                      <v-list-item-subtitle class="mt-1">{{
+                        spotDetail.area.name
+                      }}</v-list-item-subtitle>
+                    </template>
+                    <template v-if="$i18n.locale === 'en'">
+                      <v-list-item-title>{{ spotDetail.spot.name_ens }}</v-list-item-title>
+                      <v-list-item-subtitle class="mt-1">{{
+                        spotDetail.area.name_ens
+                      }}</v-list-item-subtitle>
+                    </template>
                   </v-list-item-content>
                 </v-list-item>
                 <v-card-actions>
@@ -93,7 +111,7 @@
                     color="blue darken-1 align-center"
                     text
                     @click="setSpot(spotDetail.area, spotDetail.spot)"
-                    >行ってみる！</v-btn
+                    >{{ $t('top.spot_detail') }}</v-btn
                   >
                 </v-card-actions>
               </div>
@@ -133,10 +151,18 @@
               <div class="d-flex justify-space-between">
                 <v-list-item>
                   <v-list-item-content>
-                    <v-list-item-title>{{ spotDetail.spot.name }}</v-list-item-title>
-                    <v-list-item-subtitle class="mt-1">{{
-                      spotDetail.area.name
-                    }}</v-list-item-subtitle>
+                    <template v-if="$i18n.locale === 'ja'">
+                      <v-list-item-title>{{ spotDetail.spot.name }}</v-list-item-title>
+                      <v-list-item-subtitle class="mt-1">{{
+                        spotDetail.area.name
+                      }}</v-list-item-subtitle>
+                    </template>
+                    <template v-if="$i18n.locale === 'en'">
+                      <v-list-item-title>{{ spotDetail.spot.name_ens }}</v-list-item-title>
+                      <v-list-item-subtitle class="mt-1">{{
+                        spotDetail.area.name_ens
+                      }}</v-list-item-subtitle>
+                    </template>
                   </v-list-item-content>
                 </v-list-item>
                 <v-card-actions>
@@ -144,7 +170,7 @@
                     color="blue darken-1 align-center"
                     text
                     @click="setSpot(spotDetail.area, spotDetail.spot)"
-                    >行ってみる！</v-btn
+                    >{{ $t('top.spot_detail') }}</v-btn
                   >
                 </v-card-actions>
               </div>

--- a/src/components/PrivacyPolicyEnglish.vue
+++ b/src/components/PrivacyPolicyEnglish.vue
@@ -1,0 +1,138 @@
+<template>
+  <v-card>
+    <h2 class="d-flex align-center justify-center py-3">Privacy Policy</h2>
+    <v-divider />
+    <v-col>
+      <v-responsive :aspect-ratio="16 / 9">
+        <div class="px-lg-4 px-md-3 px-sm-2">
+          <h3>Information we obtain</h3>
+          <p class="mb-1">The Service obtains the following information.</p>
+          <ul>
+            <li>Full name(including nicknames and pen names)</li>
+            <li>
+              IDs used by the customer in external services and other information that the customer
+              has authorized the linked party to disclose according to the privacy settings of the
+              external service
+            </li>
+          </ul>
+          <br />
+          <h3>Purposes for which we use your information</h3>
+          <p class="mb-1">
+            The Service will use information obtained from customers for the following purposes.
+          </p>
+          <ul>
+            <li>
+              To accept registrations, identify and authenticate customers in relation to this
+              service
+            </li>
+            <li>To manage the customer's usage history of the Service</li>
+            <li>
+              To analyze the customer's activity history on the Service and use it to maintain and
+              improve the Service
+            </li>
+            <li>To send information on affiliated businesses and services</li>
+            <li>To respond to customer inquiries</li>
+            <li>
+              To notify you of changes to this service, discontinuation of provision, termination,
+              or cancellation of the contract.
+            </li>
+            <li>
+              In addition to the above, to provide, maintain, protect and improve this service
+            </li>
+          </ul>
+          <br />
+          <h3>Measures taken for safety management</h3>
+          <p class="mb-1">
+            Regarding the measures taken by the Service to manage the security of information
+            obtained from customers, we will respond to each customer individually in accordance
+            with the provisions of laws and regulations when the customer contacts the contact
+            listed at the end of this document.
+          </p>
+          <br />
+          <h3>Third Party Offerings</h3>
+          <p class="mb-1">
+            The Service will not provide personal data (Article 2, Paragraph 6 of the Act on the
+            Protection of Personal Information) to any third party (including parties located
+            outside Japan) without prior consent from the customer. The Service will not provide
+            such information to third parties (including parties located outside of Japan) without
+            prior consent of the customer.
+          </p>
+          <ul>
+            <li>Outsourcing the handling of personal data</li>
+            <li>This service has been acquired</li>
+            <li>
+              Joint use with business partners (if there are specific joint uses, the details will
+              be announced separately).
+            </li>
+            <li>
+              Other information that is legally permitted by law to be provided to third parties
+            </li>
+          </ul>
+          <br />
+          <h3>Access Analysis Tools</h3>
+          <p class="mb-1">
+            This service uses "Google Analytics" to analyze your access to our website. Google
+            Analytics uses cookies to collect traffic data. Traffic data is collected anonymously
+            and does not personally identify you; you can refuse the collection of this information
+            by disabling cookies. Please check your browser settings for more information, or click
+            <a
+              :href="'https://marketingplatform.google.com/about/analytics/terms/jp/'"
+              target="_blank"
+              class="text-blue-600"
+              >here</a
+            >
+            to learn more about Google Analytics.
+          </p>
+          <br />
+          <h3>Privacy Policy Changes</h3>
+          <p>
+            The Service will change the contents of this Privacy Policy as necessary. In this case,
+            the Service will make known or notify you of the effective date and content of the
+            revised Privacy Policy by appropriate means.
+          </p>
+          <br />
+          <h3>Contact</h3>
+          <p>
+            If you have any comments, requests, or wish to correct, stop using, or delete user
+            information, please contact us
+            <a
+              :href="'https://forms.gle/ywb5Q35iHSBmYM4s5'"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-blue-600"
+              >here</a
+            >.
+          </p>
+        </div>
+      </v-responsive>
+    </v-col>
+    <v-divider />
+    <v-card-actions>
+      <v-spacer />
+      <v-btn color="blue darken-1" text @click="resetDialog()"> CLOSE </v-btn>
+    </v-card-actions>
+  </v-card>
+</template>
+
+<script>
+export default {
+  props: {
+    dialog: {
+      type: Boolean,
+      required: true,
+    },
+  },
+  watch: {
+    dialog() {
+      if (!this.dialog) {
+        this.resetDialog();
+      }
+    },
+  },
+  methods: {
+    resetDialog() {
+      this.$emit('reset-dialog');
+    },
+  },
+};
+</script>

--- a/src/components/TheFooter.vue
+++ b/src/components/TheFooter.vue
@@ -3,15 +3,55 @@
     <v-footer dark padless>
       <v-card flat tile width="100%" color="#5D99FF" class="white--text text-center">
         <v-card-text>
-          <v-tooltip v-for="item in items" :key="item.icon" color="teal" top>
+          <v-tooltip color="teal" top>
             <template v-slot:activator="{ on, attrs }">
               <v-btn class="mx-4 white--text" v-bind="attrs" v-on="on" icon>
-                <v-icon size="24px" @click.native="triggerClick(item.action)">
-                  {{ item.icon }}
+                <v-icon size="24px" @click.native="triggerClick('privacy')">
+                  mdi-lock-outline
                 </v-icon>
               </v-btn>
             </template>
-            <span>{{ item.text }}</span>
+            <span>{{ $t('defaults.privacy') }}</span>
+          </v-tooltip>
+          <v-tooltip color="teal" top>
+            <template v-slot:activator="{ on, attrs }">
+              <v-btn class="mx-4 white--text" v-bind="attrs" v-on="on" icon>
+                <v-icon size="24px" @click.native="triggerClick('terms')">
+                  mdi-file-document-outline
+                </v-icon>
+              </v-btn>
+            </template>
+            <span>{{ $t('defaults.terms') }}</span>
+          </v-tooltip>
+          <v-tooltip color="teal" top>
+            <template v-slot:activator="{ on, attrs }">
+              <v-btn class="mx-4 white--text" v-bind="attrs" v-on="on" icon>
+                <v-icon size="24px" @click.native="triggerClick('contact')">
+                  mdi-email-outline
+                </v-icon>
+              </v-btn>
+            </template>
+            <span>{{ $t('defaults.contact') }}</span>
+          </v-tooltip>
+          <v-tooltip color="teal" top>
+            <template v-slot:activator="{ on, attrs }">
+              <v-btn class="mx-4 white--text" v-bind="attrs" v-on="on" icon>
+                <v-icon size="24px" @click.native="triggerClick('share')">
+                  mdi-share-variant-outline
+                </v-icon>
+              </v-btn>
+            </template>
+            <span>{{ $t('defaults.app_share') }}</span>
+          </v-tooltip>
+          <v-tooltip color="teal" top>
+            <template v-slot:activator="{ on, attrs }">
+              <v-btn class="mx-4 white--text" v-bind="attrs" v-on="on" icon>
+                <v-icon size="24px" @click.native="triggerClick('twitter')">
+                  mdi-twitter
+                </v-icon>
+              </v-btn>
+            </template>
+            <span>{{ $t('defaults.twitter') }}</span>
           </v-tooltip>
         </v-card-text>
 
@@ -42,11 +82,7 @@ export default {
   data() {
     return {
       items: [
-        { icon: 'mdi-lock-outline', action: 'privacy', text: 'プライバシーポリシー' },
-        { icon: 'mdi-file-document-outline', action: 'terms', text: '利用規約' },
-        { icon: 'mdi-email-outline', action: 'contact', text: 'お問い合わせ' },
-        { icon: 'mdi-share-variant-outline', action: 'share', text: 'Twitterシェア' },
-        { icon: 'mdi-twitter', action: 'twitter', text: '開発者Twitter' },
+        { icon: 'mdi-twitter', action: 'twitter', text: this.$t('defaults.twitter') },
       ],
       privacyDialog: false,
       termsDialog: false,

--- a/src/components/TheFooter.vue
+++ b/src/components/TheFooter.vue
@@ -2,7 +2,7 @@
   <div>
     <v-footer dark padless>
       <v-card flat tile width="100%" color="#5D99FF" class="white--text text-center">
-        <v-card-text>
+        <v-card-text v-if="this.$i18n.locale === 'ja'">
           <v-tooltip color="teal" top>
             <template v-slot:activator="{ on, attrs }">
               <v-btn class="mx-4 white--text" v-bind="attrs" v-on="on" icon>
@@ -46,9 +46,58 @@
           <v-tooltip color="teal" top>
             <template v-slot:activator="{ on, attrs }">
               <v-btn class="mx-4 white--text" v-bind="attrs" v-on="on" icon>
-                <v-icon size="24px" @click.native="triggerClick('twitter')">
-                  mdi-twitter
+                <v-icon size="24px" @click.native="triggerClick('twitter')"> mdi-twitter </v-icon>
+              </v-btn>
+            </template>
+            <span>{{ $t('defaults.twitter') }}</span>
+          </v-tooltip>
+        </v-card-text>
+
+        <v-card-text v-if="this.$i18n.locale === 'en'">
+          <v-tooltip color="teal" top>
+            <template v-slot:activator="{ on, attrs }">
+              <v-btn class="mx-4 white--text" v-bind="attrs" v-on="on" icon>
+                <v-icon size="24px" @click.native="triggerClick('privacy')">
+                  mdi-lock-outline
                 </v-icon>
+              </v-btn>
+            </template>
+            <span>{{ $t('defaults.privacy') }}</span>
+          </v-tooltip>
+          <v-tooltip color="teal" top>
+            <template v-slot:activator="{ on, attrs }">
+              <v-btn class="mx-4 white--text" v-bind="attrs" v-on="on" icon>
+                <v-icon size="24px" @click.native="triggerClick('terms')">
+                  mdi-file-document-outline
+                </v-icon>
+              </v-btn>
+            </template>
+            <span>{{ $t('defaults.terms') }}</span>
+          </v-tooltip>
+          <v-tooltip color="teal" top>
+            <template v-slot:activator="{ on, attrs }">
+              <v-btn class="mx-4 white--text" v-bind="attrs" v-on="on" icon>
+                <v-icon size="24px" @click.native="triggerClick('contact')">
+                  mdi-email-outline
+                </v-icon>
+              </v-btn>
+            </template>
+            <span>{{ $t('defaults.contact') }}</span>
+          </v-tooltip>
+          <v-tooltip color="teal" top>
+            <template v-slot:activator="{ on, attrs }">
+              <v-btn class="mx-4 white--text" v-bind="attrs" v-on="on" icon>
+                <v-icon size="24px" @click.native="triggerClick('share')">
+                  mdi-share-variant-outline
+                </v-icon>
+              </v-btn>
+            </template>
+            <span>{{ $t('defaults.app_share') }}</span>
+          </v-tooltip>
+          <v-tooltip color="teal" top>
+            <template v-slot:activator="{ on, attrs }">
+              <v-btn class="mx-4 white--text" v-bind="attrs" v-on="on" icon>
+                <v-icon size="24px" @click.native="triggerClick('twitter')"> mdi-twitter </v-icon>
               </v-btn>
             </template>
             <span>{{ $t('defaults.twitter') }}</span>
@@ -64,26 +113,44 @@
 
     <!-- プライバシーポリシーダイアログボックス -->
     <v-dialog v-model="privacyDialog" max-width="1500px">
-      <Privacy @reset-dialog="closePrivacy()" :dialog="privacyDialog" />
+      <Privacy
+        v-if="this.$i18n.locale === 'ja'"
+        @reset-dialog="closePrivacy()"
+        :dialog="privacyDialog"
+      />
+      <PrivacyEnglish
+        v-if="this.$i18n.locale === 'en'"
+        @reset-dialog="closePrivacy()"
+        :dialog="privacyDialog"
+      />
     </v-dialog>
     <!-- 利用規約ダイアログボックス -->
     <v-dialog v-model="termsDialog" max-width="1200px">
-      <UseTerms @reset-dialog="closeTerms()" :dialog="termsDialog" />
+      <UseTerms
+        v-if="this.$i18n.locale === 'ja'"
+        @reset-dialog="closeTerms()"
+        :dialog="termsDialog"
+      />
+      <UseTermsEnglish
+        v-if="this.$i18n.locale === 'en'"
+        @reset-dialog="closeTerms()"
+        :dialog="termsDialog"
+      />
     </v-dialog>
   </div>
 </template>
 
 <script>
 import Privacy from './PrivacyPolicy.vue';
+import PrivacyEnglish from './PrivacyPolicyEnglish.vue';
 import UseTerms from './UseTerms.vue';
+import UseTermsEnglish from './UseTermsEnglish.vue';
 
 export default {
-  components: { Privacy, UseTerms },
+  components: { Privacy, PrivacyEnglish, UseTerms, UseTermsEnglish },
   data() {
     return {
-      items: [
-        { icon: 'mdi-twitter', action: 'twitter', text: this.$t('defaults.twitter') },
-      ],
+      items: [{ icon: 'mdi-twitter', action: 'twitter', text: this.$t('defaults.twitter') }],
       privacyDialog: false,
       termsDialog: false,
       obj: '',

--- a/src/components/TheGoogleMap.vue
+++ b/src/components/TheGoogleMap.vue
@@ -43,7 +43,6 @@ export default {
   },
   mounted() {
     let timer = setInterval(() => {
-      debugger
       const google = window.google;
       if (google) {
         clearInterval(timer);
@@ -54,12 +53,12 @@ export default {
         let markers = [];
         // クリック時に表示される情報ウィンドウ
         const infoWindow = new google.maps.InfoWindow({
-          content: "",
+          content: '',
           disableAutoPan: true,
         });
         // カーソルホバー時に表示される情報ウィンドウ
         const infoWindowHover = new google.maps.InfoWindow({
-          content: "",
+          content: '',
           disableAutoPan: true,
         });
 
@@ -109,17 +108,26 @@ export default {
             markers.push(marker);
 
             // 情報ウィンドウを固定で表示する
-            infoWindow.setContent(`<div class="mb-0"><h2>${this.spots[i].name}</h2></div>`);
+            if (this.$i18n.locale === 'ja') {
+              infoWindow.setContent(`<div class="mb-0"><h2>${this.spots[i].name}</h2></div>`);
+            } else if (this.$i18n.locale === 'en') {
+              infoWindow.setContent(`<div class="mb-0"><h2>${this.spots[i].name_ens}</h2></div>`);
+            }
             infoWindow.open(map, marker);
 
-            // infoWindowHover = new google.maps.InfoWindow({
-            //   content: `<div class="mb-0"><h2>${this.spots[i].name}</h2></div>`,
-            // });
             // マーカーをアクティブ状態にする
             this.focusMarker = marker;
             // マーカーにマウスオーバー時に地点名の情報ウィンドウを表示
             marker.addListener('mouseover', () => {
-              infoWindowHover.setContent(`<div class="mb-0"><h2>${this.spots[i].name}</h2></div>`);
+              if (this.$i18n.locale === 'ja') {
+                infoWindowHover.setContent(
+                  `<div class="mb-0"><h2>${this.spots[i].name}</h2></div>`
+                );
+              } else if (this.$i18n.locale === 'en') {
+                infoWindowHover.setContent(
+                  `<div class="mb-0"><h2>${this.spots[i].name_ens}</h2></div>`
+                );
+              }
               infoWindowHover.open(map, marker);
             });
             // マーカーからマウスアウトした時に地点名の情報ウィンドウを非表示
@@ -144,7 +152,11 @@ export default {
               // アクティブ中のマーカーのみバウンドさせる
               marker.setAnimation(google.maps.Animation.BOUNCE);
               // 情報ウィンドウを固定で表示する
-              infoWindow.setContent(`<div class="mb-0"><h2>${this.spots[i].name}</h2></div>`);
+              if (this.$i18n.locale === 'ja') {
+                infoWindow.setContent(`<div class="mb-0"><h2>${this.spots[i].name}</h2></div>`);
+              } else if (this.$i18n.locale === 'en') {
+                infoWindow.setContent(`<div class="mb-0"><h2>${this.spots[i].name_ens}</h2></div>`);
+              }
               infoWindow.open(map, marker);
               // 地点に関する動画一覧ページに遷移する処理
               this.getVideo(marker, this.spot, this.area);
@@ -180,7 +192,11 @@ export default {
               // アクティブ中のマーカーのみバウンドさせる
               marker_2[i].setAnimation(google.maps.Animation.BOUNCE);
               // 情報ウィンドウを固定で表示する
-              infoWindow.setContent(`<div class="mb-0"><h2>${this.spots[i].name}</h2></div>`);
+              if (this.$i18n.locale === 'ja') {
+                infoWindow.setContent(`<div class="mb-0"><h2>${this.spots[i].name}</h2></div>`);
+              } else if (this.$i18n.locale === 'en') {
+                infoWindow.setContent(`<div class="mb-0"><h2>${this.spots[i].name_ens}</h2></div>`);
+              }
               infoWindow.open(map, marker_2[i]);
               // 地点に関する動画一覧ページに遷移する処理
               this.getVideo(marker_2[i], this.spots[i], this.area);
@@ -190,7 +206,15 @@ export default {
 
             // マーカーにマウスオーバー時に地点名の情報ウィンドウを表示
             marker_2[i].addListener('mouseover', () => {
-              infoWindowHover.setContent(`<div class="mb-0"><h2>${this.spots[i].name}</h2></div>`);
+              if (this.$i18n.locale === 'ja') {
+                infoWindowHover.setContent(
+                  `<div class="mb-0"><h2>${this.spots[i].name}</h2></div>`
+                );
+              } else if (this.$i18n.locale === 'en') {
+                infoWindowHover.setContent(
+                  `<div class="mb-0"><h2>${this.spots[i].name_ens}</h2></div>`
+                );
+              }
               infoWindowHover.open(map, marker_2[i]);
             });
             // マーカーからマウスアウトした時に地点名の情報ウィンドウを非表示

--- a/src/components/TheHeader.vue
+++ b/src/components/TheHeader.vue
@@ -10,7 +10,7 @@
       <div class="d-flex justify-end">
         <v-btn
           v-if="this.$i18n.locale === 'en'"
-          color="blue-grey lighten-1"
+          color="teal darken-1"
           icon
           raised
           @click="changeLocale"
@@ -19,7 +19,7 @@
         </v-btn>
         <v-btn
           v-if="this.$i18n.locale === 'ja'"
-          color="blue-grey lighten-1"
+          color="cyan darken-1"
           icon
           raised
           @click="changeLocale"

--- a/src/components/TheHeader.vue
+++ b/src/components/TheHeader.vue
@@ -7,21 +7,25 @@
         <v-icon color="blue-grey lighten-1"> VtourHub </v-icon>
       </router-link>
       <v-spacer />
-      <div class="px-2 d-flex justify-end">
+      <div class="d-flex justify-end">
         <v-btn
           v-if="this.$i18n.locale === 'en'"
-          color="deep-orange darken-1"
-          outlined
+          color="blue-grey lighten-1"
+          icon
+          raised
           @click="changeLocale"
-          >Japanese</v-btn
         >
+          <Icon icon="uil:english-to-chinese" width="30" height="30" />
+        </v-btn>
         <v-btn
           v-if="this.$i18n.locale === 'ja'"
-          color="deep-orange darken-1"
-          outlined
+          color="blue-grey lighten-1"
+          icon
+          raised
           @click="changeLocale"
-          >English</v-btn
         >
+          <Icon icon="uil:english-to-chinese" width="30" height="30" />
+        </v-btn>
       </div>
       <!-- メニューアイコン -->
       <v-btn color="blue-grey lighten-1" icon @click.stop="drawer = !drawer">
@@ -35,9 +39,10 @@
 
 <script>
 import Menu from './BaseMenu.vue';
+import { Icon } from '@iconify/vue2';
 
 export default {
-  components: { Menu },
+  components: { Menu, Icon },
   data() {
     return {
       drawer: false,

--- a/src/components/TheHeader.vue
+++ b/src/components/TheHeader.vue
@@ -7,6 +7,22 @@
         <v-icon color="blue-grey lighten-1"> VtourHub </v-icon>
       </router-link>
       <v-spacer />
+      <div class="px-2 d-flex justify-end">
+        <v-btn
+          v-if="this.$i18n.locale === 'en'"
+          color="deep-orange darken-1"
+          outlined
+          @click="changeLocale"
+          >Japanese</v-btn
+        >
+        <v-btn
+          v-if="this.$i18n.locale === 'ja'"
+          color="deep-orange darken-1"
+          outlined
+          @click="changeLocale"
+          >English</v-btn
+        >
+      </div>
       <!-- メニューアイコン -->
       <v-btn color="blue-grey lighten-1" icon @click.stop="drawer = !drawer">
         <v-icon>mdi-menu</v-icon>
@@ -26,6 +42,11 @@ export default {
     return {
       drawer: false,
     };
+  },
+  methods: {
+    changeLocale() {
+      this.$i18n.locale = this.$i18n.locale === 'ja' ? 'en' : 'ja';
+    },
   },
 };
 </script>

--- a/src/components/UseTermsEnglish.vue
+++ b/src/components/UseTermsEnglish.vue
@@ -1,0 +1,228 @@
+<template>
+  <v-card>
+    <h2 class="d-flex align-center justify-center py-3">Terms of Use</h2>
+    <v-divider />
+    <v-col>
+      <v-responsive :aspect-ratio="16 / 9">
+        <div class="px-lg-4 px-md-3 px-sm-2">
+          <p class="mb-1">
+            These terms and conditions of use (hereinafter referred to as the "Terms of Use") This
+            Terms of Use ("Terms") sets forth the terms and conditions of use of the services
+            provided on this web site ("Services"). This Terms of Use ("Terms") sets forth the terms
+            and conditions of use of the services provided on this website ("Services"). Users of
+            the Service (hereinafter referred to as "Users") are requested to use the Service in
+            accordance with these Terms of Use. Users of the Service ("Users") are requested to use
+            the Service in accordance with these Terms of Use.
+          </p>
+          <br />
+          <h3>1. Adoption</h3>
+          <ol>
+            <li>
+              These Terms of Use shall apply to all relationships between the User and the
+              Administrator regarding the use of the Service.
+            </li>
+            <li>
+              In addition to these Terms of Use, the Administrator may establish various rules and
+              regulations regarding the Service, including rules for use (hereinafter referred to as
+              "Individual Regulations"). These individual provisions, regardless of their name,
+              shall constitute a part of the Terms of Use. These Individual Regulations, regardless
+              of their name, shall constitute a part of this Agreement.
+            </li>
+            <li>
+              In the event of any inconsistency between the provisions of these Terms and Conditions
+              and the individual provisions of the preceding Article, the provisions of the
+              individual provisions shall take precedence unless otherwise specified in the
+              individual provisions.
+            </li>
+          </ol>
+          <br />
+          <h3>2. User Registration</h3>
+          <ol>
+            <li>
+              The registration for this service shall be completed when a prospective registrant
+              agrees to the Terms of Use and applies for registration for use of the service in a
+              manner determined by the administrator, and when the administrator approves the
+              application.
+            </li>
+            <li>
+              The Administrator may not approve an application for registration for use if it
+              determines that the applicant has any of the following reasons, and shall not be
+              obligated to disclose the reasons for such denial.
+            </li>
+            <ul>
+              <li>False declaration was made when applying for user registration.</li>
+              <li>The application is from a person who has violated these Terms and Conditions</li>
+              <li>
+                The administrator has determined that the registration of use is not appropriate.
+              </li>
+            </ul>
+          </ol>
+          <br />
+          <h3>3. Prohibitions</h3>
+          <p class="mb-1">
+            In using the Service, the User shall not engage in any of the following acts.
+          </p>
+          <ul>
+            <li>Acts that violate laws and regulations or public order and morals</li>
+            <li>Conduct related to criminal activity</li>
+            <li>
+              Acts that infringe on copyrights, trademarks, or other intellectual property rights
+              contained in this service, including the contents of this service
+            </li>
+            <li>
+              Corrupt or interfere with the functionality of the server or network of the
+              Administrator, other users, or other third parties
+            </li>
+            <li>Commercial use of information obtained through this service</li>
+            <li>Actions that may interfere with the operation of the administrator's services</li>
+            <li>Unauthorized access or attempts to gain such access</li>
+            <li>Collecting or accumulating personal information about other users</li>
+            <li>Use of the Service for any unauthorized purpose</li>
+            <li>
+              Acts that cause disadvantage, damage, or discomfort to other users of the Service or
+              other third parties
+            </li>
+            <li>Impersonating another user</li>
+            <li>
+              Advertising, publicity, solicitation, or sales activities on the Service that are not
+              authorized by the Administrator
+            </li>
+            <li>Aiming to meet someone of the opposite sex whom you have never met before</li>
+            <li>
+              Acts of providing benefits directly or indirectly to antisocial forces in relation to
+              the administrator's services
+            </li>
+            <li>Other activities that the administrator deems inappropriate</li>
+          </ul>
+          <br />
+          <h3>4. Suspension, etc., of the Provision of this Service</h3>
+          <ol>
+            <li>
+              The Administrator may suspend or discontinue the Service, in whole or in part, without
+              prior notice to the User, for any of the following reasons.
+            </li>
+            <ul>
+              <li>
+                Perform maintenance inspections or updates of computer systems related to this
+                service
+              </li>
+              <li>
+                The provision of this service becomes difficult due to force majeure such as
+                earthquake, lightning, fire, power outage, or natural disasters
+              </li>
+              <li>Computer or communication lines, etc. stopped due to accident</li>
+              <li>
+                Other cases in which the administrator deems it difficult to provide this service
+              </li>
+            </ul>
+            <li>
+              The Administrator shall not be liable for any disadvantage or damage incurred by users
+              or third parties due to the suspension or interruption of the provision of the
+              Service.
+            </li>
+          </ol>
+          <br />
+          <h3>5. Disclaimer of Warranty and Disclaimer of Liability</h3>
+          <ol>
+            <li>
+              The Administrator makes no warranty, express or implied, that the Service will be free
+              from defects in fact or law. ( This includes defects, errors or bugs, or infringements
+              of rights with respect to safety, reliability, accuracy, completeness, validity,
+              fitness for a particular purpose, security, etc.).
+            </li>
+            <li>The Administrator assumes no responsibility for</li>
+            <ul>
+              <li>
+                Any malfunction of the PC, smart phone, or other environment used to view images
+                captured by the webcam
+              </li>
+              <li>
+                Malfunctions in the user's power generation equipment and peripheral equipment
+                caused by the use of the webcam
+              </li>
+              <li>Any other damages incurred by the User arising from the Service</li>
+            </ul>
+          </ol>
+          <br />
+          <h3>6. Changes in service content, etc.</h3>
+          <p class="mb-1">
+            The Administrator may change the contents of the Service or discontinue providing the
+            Service without notice to the User, and shall not be liable for any damages incurred by
+            the User as a result of such changes or discontinuation. The Administrator shall not be
+            liable for any damages incurred by the User as a result of such modification or
+            discontinuation.
+          </p>
+          <br />
+          <h3>7. Changes to Terms of Use</h3>
+          <p class="mb-1">
+            The Administrator reserves the right to change these Terms of Use at any time without
+            notice to the User, if deemed necessary. In the event that a user starts using the
+            Service after a modification of the Terms of Use, such user shall be deemed to have
+            agreed to the modified Terms of Use.
+          </p>
+          <br />
+          <h3>8. Handling of Personal Information</h3>
+          <p class="mb-1">
+            The Administrator shall properly handle personal information obtained through the use of
+            the Service in accordance with the Administrator's "Privacy Policy.
+          </p>
+          <br />
+          <h3>9. Notification or contact</h3>
+          <p class="mb-1">
+            Notices or communications between the User and the Administrator shall be made in a
+            manner determined by the Administrator.
+          </p>
+          <br />
+          <h3>10. Prohibition of transfer of rights and obligations</h3>
+          <p class="mb-1">
+            The User may not assign its position under the User Agreement or its rights or
+            obligations under these Terms of Use to a third party or offer them as security without
+            the prior written consent of the Administrator.
+          </p>
+          <br />
+          <h3>11. Governing Law and Jurisdiction</h3>
+          <ol>
+            <li>
+              These Terms and Conditions shall be governed by and construed in accordance with the
+              laws of Japan.
+            </li>
+            <li>
+              In the event of any dispute regarding this service, the court having jurisdiction over
+              the location of the administrator shall have exclusive jurisdiction.
+            </li>
+          </ol>
+          <br />
+          <p class="mt-4 mb-0">July 8, 2022 Formulated</p>
+        </div>
+      </v-responsive>
+    </v-col>
+    <v-divider />
+    <v-card-actions>
+      <v-spacer />
+      <v-btn color="blue darken-1" text @click="resetDialog()"> CLOSE </v-btn>
+    </v-card-actions>
+  </v-card>
+</template>
+
+<script>
+export default {
+  props: {
+    dialog: {
+      type: Boolean,
+      required: true,
+    },
+  },
+  watch: {
+    dialog() {
+      if (!this.dialog) {
+        this.resetDialog();
+      }
+    },
+  },
+  methods: {
+    resetDialog() {
+      this.$emit('reset-dialog');
+    },
+  },
+};
+</script>

--- a/src/components/WorldMap.vue
+++ b/src/components/WorldMap.vue
@@ -2,7 +2,7 @@
   <div>
     <h2 class="mb-1 d-flex align-center justify-center">
       <v-icon left bottom color="blue darken-1">mdi-map-outline</v-icon>
-      地図から探す
+      {{ $t("top.world_map") }}
     </h2>
     <v-divider class="mb-2 mx-auto" style="max-width: 1200px; width: 90%" />
     <div class="d-flex justify-center mt-5" style="margin: auto">

--- a/src/components/dialogs/HomeVideoDialog.vue
+++ b/src/components/dialogs/HomeVideoDialog.vue
@@ -14,7 +14,7 @@
       </v-responsive>
     </v-col>
     <v-card-subtitle class="py-0 font-weight-bold secondary--text">{{ title }}</v-card-subtitle>
-    <v-card-subtitle class="my-0 hidden-sm-and-down">
+    <v-card-subtitle class="my-0 pb-0 hidden-sm-and-down">
       {{
         $t('defaults.video_detail', {
           count: viewCount.toLocaleString(),
@@ -96,3 +96,14 @@ export default {
   },
 };
 </script>
+
+<!-- <style scoped>
+.shortcut {
+  width: 300px; /* 要素の横幅を指定 */
+  white-space: nowrap; /* 横幅のMAXに達しても改行しない */
+  overflow: hidden; /* ハミ出した部分を隠す */
+  text-overflow: ellipsis; /* 「…」と省略 */
+  -webkit-text-overflow: ellipsis; /* Safari */
+  -o-text-overflow: ellipsis; /* Opera */
+}
+</style> -->

--- a/src/components/dialogs/HomeVideoDialog.vue
+++ b/src/components/dialogs/HomeVideoDialog.vue
@@ -14,13 +14,36 @@
       </v-responsive>
     </v-col>
     <v-card-subtitle class="py-0 font-weight-bold secondary--text">{{ title }}</v-card-subtitle>
-    <v-card-subtitle class="my-0 hidden-sm-and-down"
-      >{{ viewCount.toLocaleString() }}回視聴・{{ publishedAt }}</v-card-subtitle
-    >
+    <v-card-subtitle class="my-0 hidden-sm-and-down">
+      {{
+        $t('defaults.video_detail', {
+          count: viewCount.toLocaleString(),
+          published_at: publishedAt,
+        })
+      }}
+    </v-card-subtitle>
     <v-col class="d-flex justify-center pt-2">
-      <v-btn color="blue darken-1" outlined @click="setSpot(area, spot)">
+      <v-btn
+        color="blue darken-1"
+        outlined
+        @click="setSpot(area, spot)"
+        style="text-transform: none"
+      >
         <v-icon left>mdi-video</v-icon>
-        {{ spot.name }}のVtour動画一覧
+        <template v-if="this.$i18n.locale === 'ja'">
+          {{
+            $t('defaults.videos', {
+              spot: spot.name,
+            })
+          }}
+        </template>
+        <template v-if="this.$i18n.locale === 'en'">
+          {{
+            $t('defaults.videos', {
+              spot: spot.name_ens,
+            })
+          }}
+        </template>
       </v-btn>
     </v-col>
     <v-divider />

--- a/src/components/dialogs/VideoDialog.vue
+++ b/src/components/dialogs/VideoDialog.vue
@@ -14,9 +14,14 @@
       </v-responsive>
     </v-col>
     <v-card-subtitle class="py-0 font-weight-bold secondary--text">{{ title }}</v-card-subtitle>
-    <v-card-subtitle class="my-0 pb-1 hidden-sm-and-down"
-      >{{ viewCount.toLocaleString() }}回視聴・{{ publishedAt }}</v-card-subtitle
-    >
+    <v-card-subtitle class="my-0 pb-1 hidden-sm-and-down">
+      {{
+        $t('defaults.video_detail', {
+          count: viewCount.toLocaleString(),
+          published_at: publishedAt,
+        })
+      }}
+    </v-card-subtitle>
     <v-col class="d-flex justify-center pt-2">
       <v-btn
         color="blue darken-1"
@@ -25,10 +30,10 @@
         @click="shareTwitter(title, videoId)"
       >
         <v-icon left>mdi-twitter</v-icon>
-        Twitterに共有
+        {{ $t('defaults.share') }}
       </v-btn>
     </v-col>
-    <v-divider class="mt-2"/>
+    <v-divider class="mt-2" />
     <v-card-actions>
       <v-spacer />
       <v-btn color="blue darken-1" text @click="resetDialog()"> CLOSE </v-btn>

--- a/src/components/dialogs/VideoDialog.vue
+++ b/src/components/dialogs/VideoDialog.vue
@@ -14,7 +14,7 @@
       </v-responsive>
     </v-col>
     <v-card-subtitle class="py-0 font-weight-bold secondary--text">{{ title }}</v-card-subtitle>
-    <v-card-subtitle class="my-0 pb-1 hidden-sm-and-down">
+    <v-card-subtitle class="my-0 pb-0 hidden-sm-and-down">
       {{
         $t('defaults.video_detail', {
           count: viewCount.toLocaleString(),

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,7 @@
 import Vue from 'vue';
 import App from './App.vue';
 import vuetify from './plugins/vuetify';
+import VueI18n from 'vue-i18n';
 import router from './router';
 import store from './store';
 
@@ -10,10 +11,25 @@ require('./plugins/jqvmap-master/dist/jquery.vmap.js');
 require('./plugins/jqvmap-master/dist/maps/jquery.vmap.world.js');
 
 Vue.config.productionTip = false;
+Vue.use(VueI18n);
+const data = require('./message.json');
+
+const i18n = new VueI18n({
+	locale: 'ja',
+	messages: data
+});
 
 new Vue({
   vuetify,
   router,
   store,
+  i18n,
+  data: {},
+  created() {},
+  methods: {
+    handleClick_changeLanguage(lang) {
+      this.$i18n.locale = lang;
+    }
+  },
   render: (h) => h(App),
 }).$mount('#app');

--- a/src/message.json
+++ b/src/message.json
@@ -1,6 +1,8 @@
 {
   "ja": {
     "defaults": {
+      "login": "ログイン",
+      "register": "新規登録",
       "my_page": "マイページ",
       "hot_spot": "ホットスポット",
       "news": "お知らせ",
@@ -12,13 +14,22 @@
       "share": "Twitterに共有"
     },
     "form": {
+      "mail": "メールアドレス",
+      "password": "パスワード",
       "area": "国を選択",
       "spot": "地名を入力",
       "request_button": "リクエストを送る",
-      "no_data": "データがありません"
+      "no_data": "データがありません",
+      "login_success": "ログインしました",
+      "logout_success": "ログアウトしました",
+      "login_error": "メールアドレスとパスワードが違います"
     },
     "validate": {
-      "request_spot": "2〜20文字が有効です"
+      "request_spot": "2〜20文字が有効です",
+      "email_presence": "メールアドレスを入力してください",
+      "email_invalid": "メールアドレスが無効です",
+      "password_presence": "パスワードを入力してください",
+      "password_invalid": "8文字以上半角英数記号のみが有効です"
     },
     "top": {
       "subtitle": "気になる街へ行こう",
@@ -59,6 +70,8 @@
   },
   "en": {
     "defaults": {
+      "login": "Login",
+      "register": "Register",
       "my_page": "Profile",
       "hot_spot": "Hot Spot",
       "news": "News",
@@ -71,13 +84,22 @@
       "no_data": "No data available"
     },
     "form": {
+      "mail": "Email",
+      "password": "password",
       "area": "Select Country",
       "spot": "Enter spot name",
       "request_button": "Send",
-      "no_data": "No data available"
+      "no_data": "No data available",
+      "login_success": "Logged in",
+      "logout_success": "Logged out",
+      "login_error": "Email and password are different"
     },
     "validate": {
-      "request_spot": "2-20 characters are valid"
+      "request_spot": "2-20 characters are valid",
+      "email_presence": "Enter your email",
+      "email_invalid": "Invalid email",
+      "password_presence": "Enter your password",
+      "password_invalid": "Only alphanumeric symbols of at least 8 characters are valid"
     },
     "top": {
       "subtitle": "Let's go to the city",

--- a/src/message.json
+++ b/src/message.json
@@ -5,7 +5,13 @@
     },
     "top": {
       "subtitle": "気になる街へ行こう",
-      "count": "%{areas}カ国 %{spots}地点を登録中"
+      "count": "%{areas}カ国 %{spots}地点を登録中",
+      "world_map": "地図から探す",
+      "new_spot": "Newスポット",
+      "hot_spot": "ホットスポット",
+      "spot_order": "ランキング第%{number}位",
+      "spot_detail": "行ってみる！",
+      "ranking_button": "ランキング一覧を見てみる"
     },
     "autocomplete": {
       "label": "国名から検索しよう",
@@ -27,7 +33,13 @@
     },
     "top": {
       "subtitle": "Let's go to the city",
-      "count": "%{areas} locations in %{spots} countries are currently registered"
+      "count": "%{areas} locations in %{spots} countries are currently registered",
+      "world_map": "Search by Map",
+      "new_spot": "New Spot",
+      "hot_spot": "Hot Spot",
+      "spot_order": "No. %{number}",
+      "spot_detail": "go！",
+      "ranking_button": "View Ranking List"
     },
     "autocomplete": {
       "label": "Search by Country",

--- a/src/message.json
+++ b/src/message.json
@@ -14,18 +14,24 @@
       "share": "Twitterに共有"
     },
     "form": {
-      "mail": "メールアドレス",
+      "name": "お名前",
+      "email": "メールアドレス",
       "password": "パスワード",
+      "password_confirmation": "パスワード確認",
       "area": "国を選択",
       "spot": "地名を入力",
       "request_button": "リクエストを送る",
       "no_data": "データがありません",
       "login_success": "ログインしました",
       "logout_success": "ログアウトしました",
-      "login_error": "メールアドレスとパスワードが違います"
+      "register_success": "新規登録が完了しました",
+      "login_error": "メールアドレスとパスワードが違います",
+      "register_error": "登録できませんでした"
     },
     "validate": {
       "request_spot": "2〜20文字が有効です",
+      "name_presence": "お名前を入力してください",
+      "name_invalid": "2〜10文字が有効です",
       "email_presence": "メールアドレスを入力してください",
       "email_invalid": "メールアドレスが無効です",
       "password_presence": "パスワードを入力してください",
@@ -84,18 +90,24 @@
       "no_data": "No data available"
     },
     "form": {
-      "mail": "Email",
-      "password": "password",
+      "name": "Name",
+      "email": "Email",
+      "password": "Password",
+      "password_confirmation": "Confirm Password",
       "area": "Select Country",
       "spot": "Enter spot name",
       "request_button": "Send",
       "no_data": "No data available",
       "login_success": "Logged in",
       "logout_success": "Logged out",
-      "login_error": "Email and password are different"
+      "register_success": "New registration completed!",
+      "login_error": "Email and password are different",
+      "register_error": "Could not register"
     },
     "validate": {
       "request_spot": "2-20 characters are valid",
+      "name_presence": "Enter your name",
+      "name_invalid": "2-10 characters are valid",
       "email_presence": "Enter your email",
       "email_invalid": "Invalid email",
       "password_presence": "Enter your password",

--- a/src/message.json
+++ b/src/message.json
@@ -1,6 +1,10 @@
 {
   "ja": {
     "defaults": {
+      "my_page": "マイページ",
+      "hot_spot": "ホットスポット",
+      "spot_order": "ランキング第%{number}位",
+      "spot_detail": "行ってみる！",
       "no-data": "データがありません"
     },
     "top": {
@@ -8,9 +12,6 @@
       "count": "%{areas}カ国 %{spots}地点を登録中",
       "world_map": "地図から探す",
       "new_spot": "Newスポット",
-      "hot_spot": "ホットスポット",
-      "spot_order": "ランキング第%{number}位",
-      "spot_detail": "行ってみる！",
       "ranking_button": "ランキング一覧を見てみる"
     },
     "autocomplete": {
@@ -18,9 +19,7 @@
       "error_message": "検索ワードを選択してください"
     },
     "menu": {
-      "my_page": "マイページ",
       "home": "トップページ",
-      "hot_spot": "ホットスポット",
       "news": "お知らせ",
       "request_spot": "スポットをリクエスト",
       "login": "ログイン",
@@ -29,6 +28,10 @@
   },
   "en": {
     "defaults": {
+      "my_page": "Profile",
+      "hot_spot": "Hot Spot",
+      "spot_order": "No. %{number}",
+      "spot_detail": "go！",
       "no-data": "No data available."
     },
     "top": {
@@ -36,9 +39,6 @@
       "count": "%{areas} locations in %{spots} countries are currently registered",
       "world_map": "Search by Map",
       "new_spot": "New Spot",
-      "hot_spot": "Hot Spot",
-      "spot_order": "No. %{number}",
-      "spot_detail": "go！",
       "ranking_button": "View Ranking List"
     },
     "autocomplete": {
@@ -46,9 +46,7 @@
       "error_message": "Please select a search word"
     },
     "menu": {
-      "my_page": "Profile",
       "home": "Top",
-      "hot_spot": "Hot Spot",
       "news": "News",
       "request_spot": "Spot Request",
       "login": "Login",

--- a/src/message.json
+++ b/src/message.json
@@ -11,7 +11,12 @@
       "spot_detail": "行ってみる！",
       "videos": "%{spot}のVtour動画一覧",
       "video_detail": "%{count}回視聴・%{published_at}",
-      "share": "Twitterに共有"
+      "share": "Twitterに共有",
+      "privacy": "プライバシーポリシー",
+      "terms": "利用規約",
+      "contact": "お問い合わせ",
+      "app_share": "Twitterシェア",
+      "twitter": "開発者Twitter"
     },
     "form": {
       "name": "お名前",
@@ -87,7 +92,12 @@
       "videos": "List of Vtour Videos %{spot}",
       "video_detail": "%{count}views・%{published_at}",
       "share": "Twitter Share",
-      "no_data": "No data available"
+      "no_data": "No data available",
+      "privacy": "Privacy Policy",
+      "terms": "Terms of Use",
+      "contact": "Contact",
+      "app_share": "Twitter Share",
+      "twitter": "Developer"
     },
     "form": {
       "name": "Name",

--- a/src/message.json
+++ b/src/message.json
@@ -1,0 +1,28 @@
+{
+  "ja": {
+    "defaults": {
+      "no-data": "データがありません"
+    },
+    "top": {
+      "subtitle": "気になる街へ行こう",
+      "count": "%{areas}カ国 %{spots}地点を登録中"
+    },
+    "autocomplete": {
+      "label": "国名から検索しよう",
+      "error_message": "検索ワードを選択してください"
+    }
+  },
+  "en": {
+    "defaults": {
+      "no-data": "No data available."
+    },
+    "top": {
+      "subtitle": "Let's go to the city",
+      "count": "%{areas} locations in %{spots} countries are currently registered"
+    },
+    "autocomplete": {
+      "label": "Search by Country",
+      "error_message": "Please select a search word"
+    }
+  }
+}

--- a/src/message.json
+++ b/src/message.json
@@ -92,7 +92,7 @@
       "request_spot": "Spot Request",
       "spot_order": "No. %{number}",
       "spot_detail": "go！",
-      "videos": "List of Vtour Videos %{spot}",
+      "videos": "List of Vtour in %{spot}",
       "video_detail": "%{count}views・%{published_at}",
       "share": "Twitter Share",
       "no_data": "No data available",
@@ -128,7 +128,7 @@
     },
     "top": {
       "subtitle": "Let's go to the city",
-      "count": "%{areas} locations in %{spots} countries are currently registered",
+      "count": "%{areas} spots in %{spots} countries are currently registered",
       "world_map": "Search by Map",
       "new_spot": "New Spot",
       "ranking_button": "View Ranking List"
@@ -157,9 +157,9 @@
       "content": "content"
     },
     "request": {
-      "main_description": "You may request the administrator of this service to add a location.",
-      "first_annotation": "※ Please note that some of the requested locations may not be added.",
-      "second_annotation": "※ You can see the added locations from the Notices column.",
+      "main_description": "You may request the administrator of this service to add a spot.",
+      "first_annotation": "※ Please note that some of the requested spots may not be added.",
+      "second_annotation": "※ You can see the added spots from the Notices column.",
       "send": "Your request has been sent!"
     },
     "share": {

--- a/src/message.json
+++ b/src/message.json
@@ -10,6 +10,15 @@
     "autocomplete": {
       "label": "国名から検索しよう",
       "error_message": "検索ワードを選択してください"
+    },
+    "menu": {
+      "my_page": "マイページ",
+      "home": "トップページ",
+      "hot_spot": "ホットスポット",
+      "news": "お知らせ",
+      "request_spot": "スポットをリクエスト",
+      "login": "ログイン",
+      "logout": "ログアウト"
     }
   },
   "en": {
@@ -23,6 +32,15 @@
     "autocomplete": {
       "label": "Search by Country",
       "error_message": "Please select a search word"
+    },
+    "menu": {
+      "my_page": "Profile",
+      "home": "Top",
+      "hot_spot": "Hot Spot",
+      "news": "News",
+      "request_spot": "Spot Request",
+      "login": "Login",
+      "logout": "Logout"
     }
   }
 }

--- a/src/message.json
+++ b/src/message.json
@@ -77,6 +77,9 @@
       "first_annotation": "※ リクエストされた地点の内、追加を見送ることもあるのでご了承ください。",
       "second_annotation": "※ お知らせ欄から追加された地点を確認することができます。",
       "send": "送信しました！"
+    },
+    "share": {
+      "content": "%{spot}にGO！"
     }
   },
   "en": {
@@ -158,6 +161,9 @@
       "first_annotation": "※ Please note that some of the requested locations may not be added.",
       "second_annotation": "※ You can see the added locations from the Notices column.",
       "send": "Your request has been sent!"
+    },
+    "share": {
+      "content": "Let's walk in %{spot_ens}!"
     }
   }
 }

--- a/src/message.json
+++ b/src/message.json
@@ -5,6 +5,9 @@
       "hot_spot": "ホットスポット",
       "spot_order": "ランキング第%{number}位",
       "spot_detail": "行ってみる！",
+      "videos": "%{spot}のVtour動画一覧",
+      "video_detail": "%{count}回視聴・%{published_at}",
+      "share": "Twitterに共有",
       "no-data": "データがありません"
     },
     "top": {
@@ -24,6 +27,11 @@
       "request_spot": "スポットをリクエスト",
       "login": "ログイン",
       "logout": "ログアウト"
+    },
+    "result": {
+      "attention": "マーカーをクリックしてください",
+      "popular": "閲覧順",
+      "new": "新着順"
     }
   },
   "en": {
@@ -32,6 +40,9 @@
       "hot_spot": "Hot Spot",
       "spot_order": "No. %{number}",
       "spot_detail": "go！",
+      "videos": "List of Vtour Videos %{spot}",
+      "video_detail": "%{count}views・%{published_at}",
+      "share": "Twitter Share",
       "no-data": "No data available."
     },
     "top": {
@@ -51,6 +62,11 @@
       "request_spot": "Spot Request",
       "login": "Login",
       "logout": "Logout"
+    },
+    "result": {
+      "attention": "Click on the marker",
+      "popular": "popular",
+      "new": "recent"
     }
   }
 }

--- a/src/message.json
+++ b/src/message.json
@@ -3,12 +3,22 @@
     "defaults": {
       "my_page": "マイページ",
       "hot_spot": "ホットスポット",
+      "news": "お知らせ",
+      "request_spot": "スポットをリクエスト",
       "spot_order": "ランキング第%{number}位",
       "spot_detail": "行ってみる！",
       "videos": "%{spot}のVtour動画一覧",
       "video_detail": "%{count}回視聴・%{published_at}",
-      "share": "Twitterに共有",
-      "no-data": "データがありません"
+      "share": "Twitterに共有"
+    },
+    "form": {
+      "area": "国を選択",
+      "spot": "地名を入力",
+      "request_button": "リクエストを送る",
+      "no_data": "データがありません"
+    },
+    "validate": {
+      "request_spot": "2〜20文字が有効です"
     },
     "top": {
       "subtitle": "気になる街へ行こう",
@@ -23,27 +33,51 @@
     },
     "menu": {
       "home": "トップページ",
-      "news": "お知らせ",
-      "request_spot": "スポットをリクエスト",
       "login": "ログイン",
       "logout": "ログアウト"
+    },
+    "profile": {
+      "attention": "スポットをお気に入り登録してみよう！",
+      "home_button": "トップページから探す",
+      "edit": "プロフィール編集"
     },
     "result": {
       "attention": "マーカーをクリックしてください",
       "popular": "閲覧順",
       "new": "新着順"
+    },
+    "news": {
+      "updated_at": "更新日",
+      "content": "内容"
+    },
+    "request": {
+      "main_description": "本サービスの管理者に対して、地点の追加をリクエストすることができます。",
+      "first_annotation": "※ リクエストされた地点の内、追加を見送ることもあるのでご了承ください。",
+      "second_annotation": "※ お知らせ欄から追加された地点を確認することができます。",
+      "send": "送信しました！"
     }
   },
   "en": {
     "defaults": {
       "my_page": "Profile",
       "hot_spot": "Hot Spot",
+      "news": "News",
+      "request_spot": "Spot Request",
       "spot_order": "No. %{number}",
       "spot_detail": "go！",
       "videos": "List of Vtour Videos %{spot}",
       "video_detail": "%{count}views・%{published_at}",
       "share": "Twitter Share",
-      "no-data": "No data available."
+      "no_data": "No data available"
+    },
+    "form": {
+      "area": "Select Country",
+      "spot": "Enter spot name",
+      "request_button": "Send",
+      "no_data": "No data available"
+    },
+    "validate": {
+      "request_spot": "2-20 characters are valid"
     },
     "top": {
       "subtitle": "Let's go to the city",
@@ -58,15 +92,28 @@
     },
     "menu": {
       "home": "Top",
-      "news": "News",
-      "request_spot": "Spot Request",
       "login": "Login",
       "logout": "Logout"
+    },
+    "profile": {
+      "attention": "Register a spot as a favorite!",
+      "home_button": "Back to Top",
+      "edit": "Edit Profile"
     },
     "result": {
       "attention": "Click on the marker",
       "popular": "popular",
       "new": "recent"
+    },
+    "news": {
+      "updated_at": "date",
+      "content": "content"
+    },
+    "request": {
+      "main_description": "You may request the administrator of this service to add a location.",
+      "first_annotation": "※ Please note that some of the requested locations may not be added.",
+      "second_annotation": "※ You can see the added locations from the Notices column.",
+      "send": "Your request has been sent!"
     }
   }
 }

--- a/src/pages/NewsList.vue
+++ b/src/pages/NewsList.vue
@@ -2,7 +2,7 @@
   <v-container>
     <h2 class="mb-1 d-flex align-center justify-center">
       <v-icon left bottom>mdi-information-outline</v-icon>
-      お知らせ
+      {{ $t('defaults.news') }}
     </h2>
     <v-divider class="mb-2" style="max-width: 700px; margin: auto" />
 
@@ -10,8 +10,8 @@
       <template v-slot:default>
         <thead>
           <tr>
-            <th class="text-left">更新日</th>
-            <th class="text-left">内容</th>
+            <th class="text-left">{{ $t("news.updated_at")}}</th>
+            <th class="text-left">{{ $t("news.content")}}</th>
           </tr>
         </thead>
         <tbody>

--- a/src/pages/NewsList.vue
+++ b/src/pages/NewsList.vue
@@ -10,14 +10,19 @@
       <template v-slot:default>
         <thead>
           <tr>
-            <th class="text-left">{{ $t("news.updated_at")}}</th>
-            <th class="text-left">{{ $t("news.content")}}</th>
+            <th class="text-left">{{ $t('news.updated_at') }}</th>
+            <th class="text-left">{{ $t('news.content') }}</th>
           </tr>
         </thead>
         <tbody>
           <tr v-for="item in newsLists" :key="item.id">
             <td>{{ item.created_at }}</td>
-            <td>{{ item.content }}</td>
+            <template v-if="$i18n.locale === 'ja'">
+              <td>{{ item.content }}</td>
+            </template>
+            <template v-if="$i18n.locale === 'en'">
+              <td>{{ item.content_ens }}</td>
+            </template>
           </tr>
         </tbody>
       </template>

--- a/src/pages/SpotRanking.vue
+++ b/src/pages/SpotRanking.vue
@@ -2,7 +2,7 @@
   <v-container class="mb-16">
     <h2 class="mb-1 d-flex align-center justify-center">
       <v-icon left bottom color="red">mdi-fire</v-icon>
-      ホットスポット
+      {{ $t('defaults.hot_spot') }}
     </h2>
 
     <v-divider class="mb-2" style="max-width: 700px; margin: auto" />
@@ -37,11 +37,19 @@
               <div class="d-flex justify-space-between">
                 <v-list-item>
                   <v-list-item-content>
-                    <v-list-item-subtitle small
-                      >ランキング第{{ spotDetail.id + 1 }}位</v-list-item-subtitle
-                    >
-                    <v-list-item-title class="my-1">{{ spotDetail.spot.name }}</v-list-item-title>
-                    <v-list-item-subtitle>{{ spotDetail.area.name }}</v-list-item-subtitle>
+                    <v-list-item-subtitle class="mb-2">
+                      {{ $t('defaults.spot_order', { number: spotDetail.id + 1 }) }}
+                    </v-list-item-subtitle>
+                    <template v-if="$i18n.locale === 'ja'">
+                      <v-list-item-title class="my-1">{{ spotDetail.spot.name }}</v-list-item-title>
+                      <v-list-item-subtitle>{{ spotDetail.area.name }}</v-list-item-subtitle>
+                    </template>
+                    <template v-if="$i18n.locale === 'en'">
+                      <v-list-item-title class="my-1">{{
+                        spotDetail.spot.name_ens
+                      }}</v-list-item-title>
+                      <v-list-item-subtitle>{{ spotDetail.area.name_ens }}</v-list-item-subtitle>
+                    </template>
                   </v-list-item-content>
                 </v-list-item>
                 <v-card-actions>
@@ -49,7 +57,7 @@
                     color="blue darken-1 align-center"
                     text
                     @click="setSpot(spotDetail.area, spotDetail.spot)"
-                    >行ってみる！</v-btn
+                    >{{ $t('defaults.spot_detail') }}</v-btn
                   >
                 </v-card-actions>
               </div>
@@ -90,20 +98,36 @@
                   <v-list-item style="width: 160px">
                     <template v-if="authUser">
                       <v-list-item-content class="pt-12">
-                        <v-list-item-subtitle class="mb-2"
-                          >ランキング第{{ spotDetail.id + 1 }}位</v-list-item-subtitle
-                        >
-                        <v-list-item-title>{{ spotDetail.spot.name }}</v-list-item-title>
-                        <v-list-item-subtitle>{{ spotDetail.area.name }}</v-list-item-subtitle>
+                        <v-list-item-subtitle class="mb-2">
+                          {{ $t('defaults.spot_order', { number: spotDetail.id + 1 }) }}
+                        </v-list-item-subtitle>
+                        <template v-if="$i18n.locale === 'ja'">
+                          <v-list-item-title>{{ spotDetail.spot.name }}</v-list-item-title>
+                          <v-list-item-subtitle>{{ spotDetail.area.name }}</v-list-item-subtitle>
+                        </template>
+                        <template v-if="$i18n.locale === 'en'">
+                          <v-list-item-title>{{ spotDetail.spot.name_ens }}</v-list-item-title>
+                          <v-list-item-subtitle>{{
+                            spotDetail.area.name_ens
+                          }}</v-list-item-subtitle>
+                        </template>
                       </v-list-item-content>
                     </template>
                     <template v-else>
                       <v-list-item-content>
-                        <v-list-item-subtitle class="mb-2"
-                          >ランキング第{{ spotDetail.id + 1 }}位</v-list-item-subtitle
-                        >
-                        <v-list-item-title>{{ spotDetail.spot.name }}</v-list-item-title>
-                        <v-list-item-subtitle>{{ spotDetail.area.name }}</v-list-item-subtitle>
+                        <v-list-item-subtitle class="mb-2">
+                          {{ $t('defaults.spot_order', { number: spotDetail.id + 1 }) }}
+                        </v-list-item-subtitle>
+                        <template v-if="$i18n.locale === 'ja'">
+                          <v-list-item-title>{{ spotDetail.spot.name }}</v-list-item-title>
+                          <v-list-item-subtitle>{{ spotDetail.area.name }}</v-list-item-subtitle>
+                        </template>
+                        <template v-if="$i18n.locale === 'en'">
+                          <v-list-item-title>{{ spotDetail.spot.name_ens }}</v-list-item-title>
+                          <v-list-item-subtitle>{{
+                            spotDetail.area.name_ens
+                          }}</v-list-item-subtitle>
+                        </template>
                       </v-list-item-content>
                     </template>
                   </v-list-item>
@@ -112,7 +136,7 @@
                     color="blue darken-1"
                     text
                     @click="setSpot(spotDetail.area, spotDetail.spot)"
-                    >行ってみる！</v-btn
+                    >{{ $t('defaults.spot_detail') }}</v-btn
                   >
                 </div>
                 <v-img

--- a/src/pages/SpotRequest.vue
+++ b/src/pages/SpotRequest.vue
@@ -2,15 +2,14 @@
   <v-container>
     <h2 class="mb-1 d-flex align-center justify-center">
       <v-icon left bottom color="green darken-1">mdi-send-circle</v-icon>
-      スポットをリクエスト
+      {{ $t('defaults.request_spot') }}
     </h2>
     <v-divider class="mb-4" style="max-width: 700px; margin: auto" />
     <p class="mb-1 d-flex align-center justify-center">
-      本サービスの管理者に対して、地点の追加をリクエストすることができます。<br />
+      {{ $t('request.main_description') }}<br />
     </p>
     <p class="d-flex justify-center" style="font-size: small">
-      ※ リクエストされた地点の内、追加を見送ることもあるのでご了承ください。<br />
-      ※ お知らせ欄から追加された地点を確認することができます。
+      {{ $t('request.first_annotation') }}<br />{{ $t('request.second_annotation') }}
     </p>
 
     <v-row justify="center" style="max-width: 1400px; margin: auto">
@@ -18,21 +17,35 @@
         <v-card>
           <v-form v-model="valid">
             <v-card-text>
-              <v-autocomplete
-                v-model="spotInfo.area"
-                :items="areas"
-                prepend-icon="mdi-earth"
-                label="国を選択"
-                no-data-text="データがありません"
-                validate-on-blur
-                required
-              >
-              </v-autocomplete>
+              <template v-if="this.$i18n.locale === 'ja'">
+                <v-autocomplete
+                  v-model="spotInfo.area"
+                  :items="areaName"
+                  prepend-icon="mdi-earth"
+                  :label="$t('form.area')"
+                  :no-data-text="$t('form.no_data')"
+                  validate-on-blur
+                  required
+                >
+                </v-autocomplete>
+              </template>
+              <template v-if="this.$i18n.locale === 'en'">
+                <v-autocomplete
+                  v-model="spotInfo.area"
+                  :items="areaNameEns"
+                  prepend-icon="mdi-earth"
+                  :label="$t('form.area')"
+                  :no-data-text="$t('form.no_data')"
+                  validate-on-blur
+                  required
+                >
+                </v-autocomplete>
+              </template>
               <v-text-field
                 v-model="spotInfo.spot"
                 :rules="spotRules"
                 prepend-icon="mdi-map-marker"
-                label="地名を入力"
+                :label="$t('form.spot')"
                 validate-on-blur
                 required
               />
@@ -44,11 +57,11 @@
                 outlined
                 class="mr-2"
                 type="button"
-                :disabled="!valid || loading"
+                :disabled="!valid"
                 :loading="loading"
                 @click="send"
               >
-                リクエストを送る
+                {{ $t('form.request_button') }}
               </v-btn>
             </v-card-actions>
           </v-form>
@@ -67,16 +80,16 @@ export default {
     return {
       valid: false,
       loading: false,
-      areas: [],
+      areaName: [],
+      areaNameEns: [],
       // フォームで選択、入力された値
       spotInfo: {
         area: null,
         spot: '',
       },
       spotRules: [
-        (v) => v.length <= 20 || '2〜20文字が有効です',
-        (v) => v.length >= 2 || '2〜20文字が有効です',
-        (v) => /^[^ -~｡-ﾟ]+$/.test(v) || '全角文字で入力してください',
+        (v) => v.length <= 20 || this.$t('validate.request_spot'),
+        (v) => v.length >= 2 || this.$t('validate.request_spot')
       ],
     };
   },
@@ -89,7 +102,10 @@ export default {
     // DB内のすべての国名を取得
     setArea() {
       axios.get('/countries').then((res) => {
-        this.areas = res.data.areas_name;
+        for (let i = 0; i < res.data.all_areas.length; i++) {
+          this.areaName.push(res.data.all_areas[i].name);
+          this.areaNameEns.push(res.data.all_areas[i].name_ens);
+        }
       });
     },
     // リクエストを送信(作成)
@@ -97,16 +113,11 @@ export default {
       axios
         .post('/requests', { request: this.spotInfo })
         .then(() => {
-          this.openSnackbar('送信しました！');
-          this.resetSpotInfo();
+          this.openSnackbar(this.$t('request.send'));
         })
         .catch((err) => {
           console.log(err);
         });
-    },
-    resetSpotInfo() {
-      this.spotInfo.area = null;
-      this.spotInfo.spot = '';
     },
   },
 };

--- a/src/pages/SpotResult.vue
+++ b/src/pages/SpotResult.vue
@@ -100,7 +100,7 @@
         {{ $t('result.attention') }}
       </v-chip>
     </template>
-    <Video :videos="videos" :area="area.name" :spot="spotName" />
+    <Video :videos="videos" :area="area.name" :spot="spotName" :spotEns="spotNameEns" />
   </v-container>
 </template>
 

--- a/src/pages/SpotResult.vue
+++ b/src/pages/SpotResult.vue
@@ -2,7 +2,12 @@
   <v-container class="mb-16">
     <h2 class="mb-1 d-flex align-center justify-center">
       <v-icon left bottom color="cyan darken-1">mdi-earth</v-icon>
-      {{ area.name }}
+      <template v-if="this.$i18n.locale === 'ja'">
+        {{ area.name }}
+      </template>
+      <template v-if="this.$i18n.locale === 'en'">
+        {{ area.name_ens }}
+      </template>
     </h2>
     <v-divider class="mb-2" style="max-width: 700px; margin: auto" />
     <v-row no-gutters class="my-5">
@@ -28,7 +33,12 @@
         >
           <h3 class="mb-2 d-flex align-center justify-center">
             <v-icon left bottom>mdi-map-marker</v-icon>
-            {{ spotName }}
+            <template v-if="this.$i18n.locale === 'ja'">
+              {{ spotName }}
+            </template>
+            <template v-if="this.$i18n.locale === 'en'">
+              {{ spotNameEns }}
+            </template>
             <!--  ログイン中のユーザーにのみお気に入りマークを表示 -->
             <template v-if="authUser">
               <v-icon
@@ -69,8 +79,8 @@
         </v-col>
         <v-col cols="12" sm="6" md="6" lg="6" class="pa-0">
           <v-tabs right v-model="currentTab">
-            <v-tab @click="viewOrder(videos)" :value="'viewTab'">閲覧順</v-tab>
-            <v-tab @click="newOrder(videos)">新着順</v-tab>
+            <v-tab @click="viewOrder(videos)" :value="'viewTab'">{{ $t('result.popular') }}</v-tab>
+            <v-tab @click="newOrder(videos)">{{ $t('result.new') }}</v-tab>
           </v-tabs>
         </v-col>
       </v-row>
@@ -87,7 +97,7 @@
         style="max-width: 700px; margin: auto"
       >
         <v-icon left>mdi-cursor-default-click-outline</v-icon>
-        マーカーをクリックしてください
+        {{ $t('result.attention') }}
       </v-chip>
     </template>
     <Video :videos="videos" :area="area.name" :spot="spotName" />
@@ -121,6 +131,7 @@ export default {
       markSpot: {},
       heart: false,
       spotName: '',
+      spotNameEns: '',
       videos: [],
       // タブのフォーカス
       currentTab: 'viewTab',
@@ -169,6 +180,7 @@ export default {
         .then((res) => {
           this.videos = res.data;
           this.spotName = spot.name;
+          this.spotNameEns = spot.name_ens;
           // お気に入り登録されているかを確認
           if (this.authUser) {
             this.bookmarked(spot);

--- a/src/pages/UserProfile.vue
+++ b/src/pages/UserProfile.vue
@@ -149,12 +149,12 @@
         style="max-width: 700px; margin: auto"
       >
         <v-icon left>mdi-heart-plus-outline</v-icon>
-        スポットをお気に入り登録してみよう！
+        {{ $t('profile.attention') }}
       </v-chip>
       <v-col class="d-flex justify-center mt-3">
-        <v-btn color="black" outlined to="/">
+        <v-btn color="black" outlined to="/" style="text-transform: none">
           <v-icon left>mdi-keyboard-backspace</v-icon>
-          トップページから探す
+          {{ $t('profile.home_button') }}
         </v-btn>
       </v-col>
     </template>
@@ -163,7 +163,7 @@
     <v-row justify="center">
       <v-dialog v-model="userDialog" max-width="600px">
         <v-card>
-          <h2 class="d-flex align-center justify-center py-2">プロフィール編集</h2>
+          <h2 class="d-flex align-center justify-center py-2">{{ $t('profile.edit') }}</h2>
           <v-divider style="max-width: 700px; margin: auto" />
           <v-form v-model="valid">
             <v-card-text class="py-0">

--- a/src/pages/UserProfile.vue
+++ b/src/pages/UserProfile.vue
@@ -2,7 +2,7 @@
   <v-container class="mb-16">
     <h1 class="mb-3 d-flex align-center justify-center">
       <v-icon left bottom color="teal darken-1">mdi-account-circle</v-icon>
-      マイページ
+      {{ $t('defaults.my_page') }}
     </h1>
 
     <v-row class="mx-auto mb-10">
@@ -53,8 +53,18 @@
                 <div class="d-flex justify-space-between">
                   <v-list-item>
                     <v-list-item-content>
-                      <v-list-item-title class="my-1">{{ spotDetail.spot.name }}</v-list-item-title>
-                      <v-list-item-subtitle>{{ spotDetail.area.name }}</v-list-item-subtitle>
+                      <template v-if="$i18n.locale === 'ja'">
+                        <v-list-item-title>{{ spotDetail.spot.name }}</v-list-item-title>
+                        <v-list-item-subtitle class="mt-1">{{
+                          spotDetail.area.name
+                        }}</v-list-item-subtitle>
+                      </template>
+                      <template v-if="$i18n.locale === 'en'">
+                        <v-list-item-title>{{ spotDetail.spot.name_ens }}</v-list-item-title>
+                        <v-list-item-subtitle class="mt-1">{{
+                          spotDetail.area.name_ens
+                        }}</v-list-item-subtitle>
+                      </template>
                     </v-list-item-content>
                   </v-list-item>
                   <v-card-actions>
@@ -62,7 +72,7 @@
                       color="blue darken-1 align-center"
                       text
                       @click="setSpot(spotDetail.area, spotDetail.spot)"
-                      >行ってみる！</v-btn
+                      >{{ $t('defaults.spot_detail') }}</v-btn
                     >
                   </v-card-actions>
                 </div>
@@ -92,8 +102,18 @@
                     />
                     <v-list-item style="width: 160px">
                       <v-list-item-content class="mt-3">
-                        <v-list-item-title>{{ spotDetail.spot.name }}</v-list-item-title>
-                        <v-list-item-subtitle>{{ spotDetail.area.name }}</v-list-item-subtitle>
+                        <template v-if="$i18n.locale === 'ja'">
+                          <v-list-item-title>{{ spotDetail.spot.name }}</v-list-item-title>
+                          <v-list-item-subtitle class="mt-1">{{
+                            spotDetail.area.name
+                          }}</v-list-item-subtitle>
+                        </template>
+                        <template v-if="$i18n.locale === 'en'">
+                          <v-list-item-title>{{ spotDetail.spot.name_ens }}</v-list-item-title>
+                          <v-list-item-subtitle class="mt-1">{{
+                            spotDetail.area.name_ens
+                          }}</v-list-item-subtitle>
+                        </template>
                       </v-list-item-content>
                     </v-list-item>
                     <v-divider />
@@ -101,7 +121,7 @@
                       color="blue darken-1 align-center"
                       text
                       @click="setSpot(spotDetail.area, spotDetail.spot)"
-                      >行ってみる！</v-btn
+                      >{{ $t('defaults.spot_detail') }}</v-btn
                     >
                   </div>
                   <v-img
@@ -268,8 +288,7 @@ export default {
     clickCount(spot, area) {
       axios
         .get(`/countries/${area.id}/spots/${spot.id}/edit`)
-        .then(() => {
-        })
+        .then(() => {})
         .catch((error) => {
           console.log(error);
         });

--- a/src/pages/auth/TheLogin.vue
+++ b/src/pages/auth/TheLogin.vue
@@ -15,7 +15,7 @@
                 v-model="user.email"
                 :rules="emailRules"
                 prepend-icon="mdi-email"
-                :label="$t('form.mail')"
+                :label="$t('form.email')"
                 validate-on-blur
                 required
               />

--- a/src/pages/auth/TheLogin.vue
+++ b/src/pages/auth/TheLogin.vue
@@ -2,7 +2,7 @@
   <v-container>
     <h2 class="mb-1 d-flex align-center justify-center">
       <v-icon left bottom>mdi-login</v-icon>
-      ログイン
+      {{ $t('defaults.login') }}
     </h2>
     <v-divider class="mb-4" style="max-width: 700px; margin: auto" />
 
@@ -15,7 +15,7 @@
                 v-model="user.email"
                 :rules="emailRules"
                 prepend-icon="mdi-email"
-                label="メールアドレス"
+                :label="$t('form.mail')"
                 validate-on-blur
                 required
               />
@@ -26,8 +26,7 @@
                 prepend-icon="mdi-lock"
                 :append-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
                 :type="showPassword ? 'text' : 'password'"
-                label="パスワード"
-                placeholder="8〜12文字"
+                :label="$t('form.password')"
                 validate-on-blur
                 required
                 @click:append="showPassword = !showPassword"
@@ -45,14 +44,17 @@
                 :loading="loading"
                 @click="login"
               >
-                ログイン
+                {{ $t('defaults.login') }}
               </v-btn>
             </v-card-actions>
           </v-form>
 
           <v-divider />
-          <v-card-text class="text-center">
+          <v-card-text class="text-center" v-if="this.$i18n.locale === 'ja'">
             新規登録は<router-link to="/register">こちら</router-link>
+          </v-card-text>
+          <v-card-text class="text-center" v-if="this.$i18n.locale === 'en'">
+            Click <router-link to="/register">here</router-link> for new registration
           </v-card-text>
         </v-card>
       </v-col>
@@ -75,14 +77,14 @@ export default {
       },
       // メールアドレスのバリデーション
       emailRules: [
-        (v) => !!v || 'メールアドレスを入力してください',
-        (v) => /.+@.+\..+/.test(v) || '無効なメールアドレスです',
+        (v) => !!v || this.$t('validate.email_presence'),
+        (v) => /.+@.+\..+/.test(v) || this.$t('validate.email_invalid'),
       ],
       // パスワードのバリデーション
       passwordRules: [
-        (v) => !!v || 'パスワードを入力してください',
-        (v) => v.length >= 8 || '8文字以上半角英数記号のみが有効です',
-        (v) => /^[a-zA-Z0-9!-/:-@¥[-`{-~]*$/.test(v) || '8文字以上半角英数記号のみが有効です',
+        (v) => !!v || this.$t('validate.password_presence'),
+        (v) => v.length >= 8 || this.$t('validate.password_invalid'),
+        (v) => /^[a-zA-Z0-9!-/:-@¥[-`{-~]*$/.test(v) || this.$t('validate.password_invalid'),
       ],
       // パスワードの表示状態を表す(trueで表示)
       showPassword: false,
@@ -97,21 +99,16 @@ export default {
 
         // 異常系
         if (status === 'fail') {
-          this.openSnackbar('メールアドレスとパスワードが違います');
-          this.resetUser();
+          this.openSnackbar(this.$t('form.login_error'));
           return;
         }
 
         // 正常系
         this.$router.push({ name: 'UserProfile' });
-        this.openSnackbar('ログインしました');
+        this.openSnackbar(this.$t('form.login_success'));
       } catch (error) {
         console.log(error);
       }
-    },
-    resetUser() {
-      this.user.email = '';
-      this.user.password = '';
     },
   },
 };

--- a/src/pages/auth/TheRegister.vue
+++ b/src/pages/auth/TheRegister.vue
@@ -2,7 +2,7 @@
   <v-container>
     <h2 class="mb-1 d-flex align-center justify-center">
       <v-icon left bottom>mdi-account-plus</v-icon>
-      新規登録
+      {{ $t('defaults.register') }}
     </h2>
     <v-divider class="mb-4" style="max-width: 700px; margin: auto" />
 
@@ -15,8 +15,7 @@
                 v-model="user.name"
                 :rules="nameRules"
                 prepend-icon="mdi-account-circle"
-                label="お名前"
-                placeholder="2〜10文字"
+                :label="$t('form.name')"
                 validate-on-blur
                 required
               />
@@ -25,7 +24,7 @@
                 v-model="user.email"
                 :rules="emailRules"
                 prepend-icon="mdi-email"
-                label="メールアドレス"
+                :label="$t('form.email')"
                 validate-on-blur
                 required
               />
@@ -36,8 +35,7 @@
                 prepend-icon="mdi-lock"
                 :append-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
                 :type="showPassword ? 'text' : 'password'"
-                label="パスワード"
-                placeholder="8〜12文字"
+                :label="$t('form.password')"
                 validate-on-blur
                 required
                 @click:append="showPassword = !showPassword"
@@ -49,8 +47,7 @@
                 prepend-icon="mdi-lock-outline"
                 :append-icon="showPasswordConfirmation ? 'mdi-eye' : 'mdi-eye-off'"
                 :type="showPasswordConfirmation ? 'text' : 'password'"
-                label="パスワード確認"
-                placeholder="8〜12文字"
+                :label="$t('form.password_confirmation')"
                 validate-on-blur
                 required
                 @click:append="showPasswordConfirmation = !showPasswordConfirmation"
@@ -67,14 +64,17 @@
                 :disabled="!valid"
                 @click="register"
               >
-                新規登録
+                {{ $t('defaults.register') }}
               </v-btn>
             </v-card-actions>
           </v-form>
 
           <v-divider />
-          <v-card-text class="text-center">
+          <v-card-text class="text-center" v-if="this.$i18n.locale === 'ja'">
             ログインは<router-link to="/login">こちら</router-link>
+          </v-card-text>
+          <v-card-text class="text-center" v-if="this.$i18n.locale === 'en'">
+            Click <router-link to="/login">here</router-link> for login
           </v-card-text>
         </v-card>
       </v-col>
@@ -97,18 +97,18 @@ export default {
         password_confirmation: '',
       },
       nameRules: [
-        (v) => !!v || 'お名前を入力してください',
-        (v) => v.length <= 10 || '2〜10文字が有効です',
-        (v) => v.length >= 2 || '2〜10文字が有効です',
+        (v) => !!v || this.$t('validate.name_presence'),
+        (v) => v.length <= 10 || this.$t('validate.name_invalid'),
+        (v) => v.length >= 2 || this.$t('validate.name_invalid'),
       ],
       emailRules: [
-        (v) => !!v || 'メールアドレスを入力してください',
-        (v) => /.+@.+\..+/.test(v) || '無効なメールアドレスです',
+        (v) => !!v || this.$t('validate.email_presence'),
+        (v) => /.+@.+\..+/.test(v) || this.$t('validate.email_invalid'),
       ],
       passwordRules: [
-        (v) => !!v || 'パスワードを入力してください',
-        (v) => v.length >= 8 || '8文字以上半角英数記号のみが有効です',
-        (v) => /^[a-zA-Z0-9!-/:-@¥[-`{-~]*$/.test(v) || '8文字以上半角英数記号のみが有効です',
+        (v) => !!v || this.$t('validate.password_presence'),
+        (v) => v.length >= 8 || this.$t('validate.password_invalid'),
+        (v) => /^[a-zA-Z0-9!-/:-@¥[-`{-~]*$/.test(v) || this.$t('validate.password_invalid'),
       ],
       showPassword: false,
       showPasswordConfirmation: false,
@@ -125,23 +125,16 @@ export default {
 
         // 異常系
         if (status === 'fail') {
-          this.openSnackbar('登録できませんでした');
-          this.resetUser();
+          this.openSnackbar(this.$t('form.register_error'));
           return;
         }
 
         // 正常系
         this.$router.push({ name: 'Login' });
-        this.openSnackbar('新規登録が完了しました');
+        this.openSnackbar(this.$t('form.register_success'));
       } catch (error) {
         console.log(error);
       }
-    },
-    resetUser() {
-      this.user.name = '';
-      this.user.email = '';
-      this.user.password = '';
-      this.user.password_confirmation = '';
     },
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5811,6 +5811,11 @@ vue-hot-reload-api@^2.3.0:
   resolved "https://registry.npmmirror.com/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz#532955cc1eb208a3d990b3a9f9a70574657e08f2"
   integrity sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog==
 
+vue-i18n@8:
+  version "8.27.2"
+  resolved "https://registry.yarnpkg.com/vue-i18n/-/vue-i18n-8.27.2.tgz#b649a65ff42b7d1a482679b732902f889965a068"
+  integrity sha512-QVzn7u2WVH8F7eSKIM00lujC7x1mnuGPaTnDTmB01Hd709jDtB9kYtBqM+MWmp5AJRx3gnqAdZbee9MelqwFBg==
+
 vue-loader@^17.0.0:
   version "17.0.0"
   resolved "https://registry.npmmirror.com/vue-loader/-/vue-loader-17.0.0.tgz#2eaa80aab125b19f00faa794b5bd867b17f85acb"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1008,6 +1008,11 @@
   resolved "https://registry.npmmirror.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
+"@iconify/vue2@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@iconify/vue2/-/vue2-1.2.1.tgz#f858bcfe8554970cca6d8f4c7a7e8015c7933fbb"
+  integrity sha512-aJy/PLs0mqKF5wv6vMc+Pf2+v4TkrlLP15tTU15Tbyw5OSnIGZa64eCkEEJnag2h8+XIf/mx6MOf7m2DE58pHw==
+
 "@jridgewell/gen-mapping@^0.1.0":
   version "0.1.1"
   resolved "https://registry.npmmirror.com/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz#e5d2e450306a9491e3bd77e323e38d7aff315996"


### PR DESCRIPTION
## 実装内容

* 追加：Vue I18nを導入 https://github.com/O-H-K-N/walk-tour-vue/pull/41/commits/6678e4fbaba7540f48317bdf32cdac6e2d2f6889 
* 追加：vue-i18nの読み込みと日本語、英語切り替えボタンを実装 https://github.com/O-H-K-N/walk-tour-vue/pull/41/commits/dfd03f05e6776d5c756cb4feb848dba777f626e8 https://github.com/O-H-K-N/walk-tour-vue/pull/41/commits/9ed19919f235139bd8081a6e815c5fc3012fc7a4 
* 追加：トップページ見出しに多言語化（英語）を適用 https://github.com/O-H-K-N/walk-tour-vue/pull/41/commits/b377ab2c9925137ca3b37fcc74a93d116bc5a8ae 
* 追加：メニューバーに多言語化を適用 https://github.com/O-H-K-N/walk-tour-vue/pull/41/commits/319cf849774d4bcde7dc9792976ed7c8a81bcf5e 
* 追加：トップページの各コンポーネントに多言語化を適用 https://github.com/O-H-K-N/walk-tour-vue/pull/41/commits/5587c9cf7049faf97904692897b368df47dc9663 
* 追加：ランキングページとマイページにに多言語化を適用 https://github.com/O-H-K-N/walk-tour-vue/pull/41/commits/8b4239e3720842c39c004da075d3efbb89daf000 
* 追加：国詳細ページと動画のダイアログに多言語化を適用 https://github.com/O-H-K-N/walk-tour-vue/pull/41/commits/388611adb63110544128b9761b78430d0a35085e 
* 追加：お知らせページとスポットリクエストページに多言語化を適用 https://github.com/O-H-K-N/walk-tour-vue/pull/41/commits/fbaa79e422567d006297548b0e409e235ab21412 
* 追加：ログイン、ログアウト処理に多言語化を適用 https://github.com/O-H-K-N/walk-tour-vue/pull/41/commits/f613f8960cb209a81ea2e016798c06dade2f0fe6 
* 追加：新規登録処理に多言語化を適用 https://github.com/O-H-K-N/walk-tour-vue/pull/41/commits/6bdb304fbb75ad188b8bd3f9cc8576018c19491d 
* 追加：フッターに多言語化を適用 https://github.com/O-H-K-N/walk-tour-vue/pull/41/commits/36b7525e99e1d5093a51cd09d780d6bbc5dad92a 
* 追加：プライバシーポリシー、利用規約にに多言語化を適用 https://github.com/O-H-K-N/walk-tour-vue/pull/41/commits/59275481ba8238f4e433072ee27cde8209ec2a5f 
* 追加：Twitterシェアに多言語化を適用 https://github.com/O-H-K-N/walk-tour-vue/pull/41/commits/c0d24069aa60d8d3808a070d15d2d349011e7744 
* 追加：言語切り替えボタンを実装 https://github.com/O-H-K-N/walk-tour-vue/pull/41/commits/9ed19919f235139bd8081a6e815c5fc3012fc7a4 
* 追加：お知らせに英訳がされるように実装 https://github.com/O-H-K-N/walk-tour-vue/pull/41/commits/e35f7def29dd3f37cb2dc30a6ccbfdee4a30508b 